### PR TITLE
Docs/swagger api coverage

### DIFF
--- a/src/controllers/products.controller.js
+++ b/src/controllers/products.controller.js
@@ -10,37 +10,6 @@ import logger from "../config/logger.js";
 import { formatResponse } from "../utils/responseFormatter.js";
 
 /**
- * @swagger
- * /products:
- *   get:
- *     summary: Retrieve all published products
- *     description: Retrieve all published products
- *     tags:
- *       - Products
- *     parameters:
- *       - in: query
- *         name: page
- *         required: false
- *         schema:
- *           type: integer
- *           default: 1
- *       - in: query
- *         name: limit
- *         required: false
- *         schema:
- *           type: integer
- *           default: 10
- *     responses:
- *       200:
- *         description: A list of published products
- *         content:
- *           application/json:
- *             schema:
- *               type: array
- *               items:
- *                 $ref: '#/components/schemas/Product'
- */
-/**
  * Fetches a paginated list of published products.
  * @async
  * @function getProducts
@@ -83,28 +52,6 @@ export async function getProducts(req, res) {
 }
 
 /**
- * @swagger
- * /products/{id}:
- *   get:
- *     summary: Retrieve a published product by ID
- *     description: Retrieve a published product by ID
- *     tags:
- *       - Products
- *     parameters:
- *      - in: path
- *        name: id
- *        required: true
- *        schema:
- *          type: string
- *     responses:
- *       200:
- *         description: A published product
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/Product'
- */
-/**
  * Retrieves a single published product by its ID.
  * @async
  * @function getProductByIdHandler
@@ -140,45 +87,6 @@ export async function getProductByIdHandler(req, res) {
 }
 
 /**
- * @swagger
- * /products:
- *   post:
- *     summary: Create a new product
- *     description: Create a new product
- *     tags:
- *       - Products
- *     requestBody:
- *       description: Product data to create
- *       required: true
- *       content:
- *         application/json:
- *           schema:
- *             type: object
- *             properties:
- *               name:
- *                 type: string
- *               description:
- *                 type: string
- *               price:
- *                 type: number
- *               images:
- *                 type: array
- *                 items:
- *                   type: string
- *                 maxItems: 5
- *               category:
- *                 type: string
- *               stock:
- *                 type: integer
- *     responses:
- *       201:
- *         description: Created product
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/Product'
- */
-/**
  * Creates a new product using request body data.
  * @async
  * @function createProductHandler
@@ -205,51 +113,6 @@ export async function createProductHandler(req, res) {
   }
 }
 
-/**
- * @swagger
- * /products/{id}:
- *   put:
- *     summary: Update an existing product
- *     description: Update an existing product
- *     tags:
- *       - Products
- *     parameters:
- *      - in: path
- *        name: id
- *        required: true
- *        schema:
- *          type: string
- *     requestBody:
- *       description: Product data to update
- *       required: true
- *       content:
- *         application/json:
- *           schema:
- *             type: object
- *             properties:
- *               name:
- *                 type: string
- *               description:
- *                 type: string
- *               price:
- *                 type: number
- *               images:
- *                 type: array
- *                 items:
- *                   type: string
- *                 maxItems: 5
- *               category:
- *                 type: string
- *               stock:
- *                 type: integer
- *     responses:
- *       200:
- *         description: Updated product
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/Product'
- */
 /**
  * Updates an existing product by ID using request body data.
  * @async
@@ -285,24 +148,6 @@ export async function updateProductHandler(req, res) {
   }
 }
 
-/**
- * @swagger
- * /products/{id}:
- *   delete:
- *     summary: Delete a product by ID
- *     description: Delete a product by ID
- *     tags:
- *       - Products
- *     parameters:
- *      - in: path
- *        name: id
- *        required: true
- *        schema:
- *          type: string
- *     responses:
- *       204:
- *         description: Product deleted
- */
 /**
  * Deletes a product by its ID.
  * @async

--- a/src/controllers/products.controller.js
+++ b/src/controllers/products.controller.js
@@ -7,6 +7,7 @@ import {
   countPublishedProducts,
 } from "../models/product.model.js";
 import logger from "../config/logger.js";
+import { formatResponse } from "../utils/responseFormatter.js";
 
 /**
  * @swagger
@@ -72,7 +73,12 @@ export async function getProducts(req, res) {
     logger.error(
       `[products.controller] Failed to fetch products: ${error.message}`
     );
-    res.status(500).json({ error: "Failed to load products" });
+    res.status(500).json(
+      formatResponse({
+        success: false,
+        error: "Failed to load products",
+      })
+    );
   }
 }
 
@@ -112,14 +118,24 @@ export async function getProductByIdHandler(req, res) {
     const { id } = req.params;
     const product = await getProductById(id);
     if (!product || !product.isPublished) {
-      return res.status(404).json({ error: "Product not found" });
+      return res.status(404).json(
+        formatResponse({
+          success: false,
+          error: "Product not found",
+        })
+      );
     }
-    res.json(product);
+    res.json(formatResponse({ data: product }));
   } catch (error) {
     logger.error(
       `[products.controller] Error getting product ${req.params.id}: ${error.message}`
     );
-    res.status(500).json({ error: "Failed to load product " });
+    res.status(500).json(
+      formatResponse({
+        success: false,
+        error: "Failed to load product ",
+      })
+    );
   }
 }
 
@@ -175,12 +191,17 @@ export async function createProductHandler(req, res) {
   try {
     const data = { ...req.body, createdBy: req.user._id };
     const product = await createProduct(data);
-    res.status(201).json(product);
+    res.status(201).json(formatResponse({ data: product }));
   } catch (error) {
     logger.error(
       `[products.controller] Error creating product: ${error.message}`
     );
-    res.status(400).json({ error: "Invalid product data" });
+    res.status(400).json(
+      formatResponse({
+        success: false,
+        error: "Invalid product data",
+      })
+    );
   }
 }
 
@@ -243,14 +264,24 @@ export async function updateProductHandler(req, res) {
     const { id } = req.params;
     const product = await updateProduct(id, req.body);
     if (!product) {
-      return res.status(404).json({ error: "Product not found" });
+      return res.status(404).json(
+        formatResponse({
+          success: false,
+          error: "Product not found",
+        })
+      );
     }
-    res.json(product);
+    res.json(formatResponse({ data: product }));
   } catch (error) {
     logger.error(
       `[products.controller] Product update failed: ${error.message}`
     );
-    res.status(400).json({ error: "Product update failed" });
+    res.status(400).json(
+      formatResponse({
+        success: false,
+        error: "Product update failed",
+      })
+    );
   }
 }
 
@@ -286,13 +317,23 @@ export async function deleteProductHandler(req, res) {
     const { id } = req.params;
     const deleted = await deleteProduct(id);
     if (!deleted) {
-      return res.status(404).json({ error: "Product not found" });
+      return res.status(404).json(
+        formatResponse({
+          success: false,
+          error: "Product not found",
+        })
+      );
     }
     res.status(204).send();
   } catch (error) {
     logger.error(
       `[products.controller] Product deletion failed: ${error.message}`
     );
-    res.status(400).json({ error: "Product deletion failed" });
+    res.status(400).json(
+      formatResponse({
+        success: false,
+        error: "Product deletion failed",
+      })
+    );
   }
 }

--- a/src/controllers/users.controller.js
+++ b/src/controllers/users.controller.js
@@ -64,7 +64,12 @@ async function loginUser(req, res, next) {
   passport.authenticate("local", { session: false }, (err, user, info) => {
     if (err || !user) {
       logger.warn(`[loginUser] Login failed: ${info?.message || err.message}`);
-      return res.status(401).json({ message: "Invalid credentials" });
+      return res.status(401).json(
+        formatResponse({
+          success: false,
+          message: "Invalid credentials",
+        })
+      );
     }
 
     try {
@@ -72,7 +77,12 @@ async function loginUser(req, res, next) {
       return finalizeAuth(req, res);
     } catch (error) {
       logger.error(`[loginUser] User JWT generation failed: ${error.message}`);
-      return res.status(500).json({ error: "Token generation error" });
+      return res.status(500).json(
+        formatResponse({
+          success: false,
+          error: "Token generation error",
+        })
+      );
     }
   })(req, res, next);
 }
@@ -147,8 +157,8 @@ export async function getCurrentUser(req, res) {
 /**
  * Helper function to finalize authentication workflow
  * - Generates a JWT with user ID and role as payload
- * - In production, sends an http-only cookie with the token
- * - In development, returns a JSON response with the token and basic user data
+ * - Sets an http-only cookie with the token with environment aware options
+ * - Returns a JSON response with basic user data and logs the token in development
  * - Handles errors with structured response and logging
  *
  * @param {Object} req   - Express request object

--- a/src/routes/auth.routes.js
+++ b/src/routes/auth.routes.js
@@ -14,7 +14,7 @@ const router = express.Router();
 
 /**
  * @swagger
- * /signup:
+ * /auth/signup:
  *   post:
  *     summary: Registers a new user with email, password, and optional displayName
  *     description: Registers a new user with email, password, and optional displayName
@@ -30,10 +30,13 @@ const router = express.Router();
  *             properties:
  *               email:
  *                 type: string
+ *                 description: User's email address
  *               password:
  *                 type: string
+ *                 description: User's password
  *               displayName:
  *                 type: string
+ *                 description: User's display name (optional)
  *     responses:
  *       201:
  *         description: Created user
@@ -42,16 +45,58 @@ const router = express.Router();
  *             schema:
  *               type: object
  *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   description: Indicates whether the user was created successfully
  *                 message:
  *                   type: string
- *                 userId:
+ *                   description: Success or error message
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     userId:
+ *                       type: string
+ *                       description: Created user's ID
+ *                     email:
+ *                       type: string
+ *                       description: Created user's email address
+ *                     displayName:
+ *                       type: string
+ *                       description: Created user's display name (if provided)
+ *       400:
+ *         description: Invalid user credentials
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   description: Indicates whether the user was created successfully
+ *                   example: false
+ *                 message:
  *                   type: string
+ *                   description: Error message
+ *       500:
+ *         description: Failed to create user
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   description: Indicates whether the user was created successfully
+ *                   example: false
+ *                 error:
+ *                   type: string
+ *                   description: Error message
  */
 router.post("/signup", validateUser, registerUser);
 
 /**
  * @swagger
- * /login:
+ * /auth/login:
  *   post:
  *     summary: Authenticates a user and issues a signed JWT
  *     description: Authenticates a user and issues a signed JWT
@@ -67,8 +112,10 @@ router.post("/signup", validateUser, registerUser);
  *             properties:
  *               email:
  *                 type: string
+ *                 description: User's email address
  *               password:
  *                 type: string
+ *                 description: User's password
  *     responses:
  *       200:
  *         description: User authenticated
@@ -79,14 +126,56 @@ router.post("/signup", validateUser, registerUser);
  *               properties:
  *                 message:
  *                   type: string
+ *                   description: Success message
  *                 token:
  *                   type: string
+ *                   description: Signed JWT token
+ *                 user:
+ *                   type: object
+ *                   properties:
+ *                     userId:
+ *                       type: string
+ *                       description: User's ID
+ *                     email:
+ *                       type: string
+ *                       description: User's email address
+ *                     displayName:
+ *                       type: string
+ *                       description: User's display name
+ *       401:
+ *         description: Invalid credentials
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   description: Indicates whether the user was authenticated successfully
+ *                   example: false
+ *                 message:
+ *                   type: string
+ *                   description: Error message
+ *       500:
+ *         description: Token generation error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   description: Indicates whether the user was authenticated successfully
+ *                   example: false
+ *                 error:
+ *                   type: string
+ *                   description: Error message
  */
 router.post("/login", loginUser);
 
 /**
  * @swagger
- * /google:
+ * /auth/google:
  *   get:
  *     summary: Initiates Google OAuth login flow
  *     description: Initiates Google OAuth login flow
@@ -103,15 +192,32 @@ router.get(
 
 /**
  * @swagger
- * /google/callback:
+ * /auth/google/callback:
  *   get:
- *     summary: Handles Google OAuth callback and issues token
- *     description: Handles Google OAuth callback and issues token
+ *     summary: Handles Google OAuth callback and authenticates user
+ *     description: Handles Google OAuth callback and authenticates user
  *     tags:
  *       - Users
  *     responses:
  *       302:
- *         description: Redirects to frontend with token in query string
+ *         description: Redirects to frontend with authentication cookie
+ *       500:
+ *         description: Authentication failed
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   description: Indicates whether the authentication was successful
+ *                   example: false
+ *                 message:
+ *                   type: string
+ *                   description: Error message
+ *                 error:
+ *                   type: string
+ *                   description: Error message
  */
 router.get(
   "/google/callback",
@@ -121,7 +227,7 @@ router.get(
 
 /**
  * @swagger
- * /me:
+ * /auth/me:
  *   get:
  *     summary: Retrieves the currently authenticated user
  *     description: Retrieves the currently authenticated user
@@ -148,6 +254,18 @@ router.get(
  *                       type: string
  *                     displayName:
  *                       type: string
+ *       401:
+ *         description: User not authenticated
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   example: false
+ *                 message:
+ *                   type: string
  */
 router.get("/me", authenticateToken, getCurrentUser);
 

--- a/src/routes/products.routes.js
+++ b/src/routes/products.routes.js
@@ -18,15 +18,76 @@ const router = express.Router();
  *   get:
  *     summary: Fetch all published products
  *     description: Fetch all published products
+ *     tags:
+ *       - Products
+ *     parameters:
+ *       - in: query
+ *         name: page
+ *         required: false
+ *         schema:
+ *           type: integer
+ *           default: 1
+ *       - in: query
+ *         name: limit
+ *         required: false
+ *         schema:
+ *           type: integer
+ *           default: 10
  *     responses:
  *       200:
- *         description: A list of products
+ *         description: A list of published products
  *         content:
  *           application/json:
  *             schema:
- *               type: array
- *               items:
- *                 $ref: '#/components/schemas/Product'
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   description: Indicates whether the request was successful
+ *                 data:
+ *                   type: array
+ *                   items:
+ *                     $ref: "#/components/schemas/Product"
+ *                 total:
+ *                   type: integer
+ *                   description: Total number of published products
+ *                 totalPages:
+ *                   type: integer
+ *                   description: Total number of pages available
+ *                 currentPage:
+ *                   type: integer
+ *                   description: Current page number
+ *               example:
+ *                 success: true
+ *                 data:
+ *                   - id: "product1"
+ *                     name: "Product 1"
+ *                     description: "Description of Product 1"
+ *                     price: 19.99
+ *                     published: true
+ *                   - id: "product2"
+ *                     name: "Product 2"
+ *                     description: "Description of Product 2"
+ *                     price: 29.99
+ *                     published: true
+ *                 total: 2
+ *                 totalPages: 1
+ *                 currentPage: 1
+ *       500:
+ *         description: Failed to load products
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   description: Indicates whether the request was successful
+ *                   example: false
+ *                 error:
+ *                   type: string
+ *                   description: Error message
+ *                   example: "Failed to load products"
  */
 router.get("/", getProducts);
 
@@ -36,19 +97,50 @@ router.get("/", getProducts);
  *   get:
  *     summary: Fetch a published product by ID
  *     description: Fetch a published product by ID
+ *     tags:
+ *       - Products
  *     parameters:
- *      - in: path
- *        name: id
- *        required: true
- *        schema:
- *          type: string
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
  *     responses:
  *       200:
  *         description: A product
  *         content:
  *           application/json:
  *             schema:
- *               $ref: '#/components/schemas/Product'
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   description: Indicates whether the request was successful
+ *                 data:
+ *                   $ref: "#/components/schemas/Product"
+ *               example:
+ *                 success: true
+ *                 data:
+ *                   id: "product1"
+ *                   name: "Product 1"
+ *                   description: "Description of Product 1"
+ *                   price: 19.99
+ *                   published: true
+ *       500:
+ *         description: Failed to load product
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   description: Indicates whether the request was successful
+ *                   example: false
+ *                 error:
+ *                   type: string
+ *                   description: Error message
+ *                   example: "Failed to load product"
  */
 router.get("/:id", getProductByIdHandler);
 
@@ -58,21 +150,44 @@ router.get("/:id", getProductByIdHandler);
  *   post:
  *     summary: Create a new product
  *     description: Create a new product
- *     security:
- *      - bearerAuth: []
+ *     tags:
+ *       - Products
  *     requestBody:
+ *       description: Product data to create
  *       required: true
  *       content:
  *         application/json:
  *           schema:
- *             $ref: '#/components/schemas/Product'
+ *             $ref: "#/components/schemas/Product"
  *     responses:
  *       201:
  *         description: Created product
  *         content:
  *           application/json:
  *             schema:
- *               $ref: '#/components/schemas/Product'
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   description: Indicates whether the request was successful
+ *                   example: true
+ *                 data:
+ *                   $ref: "#/components/schemas/Product"
+ *       400:
+ *         description: Invalid product data
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   description: Indicates whether the request was successful
+ *                   example: false
+ *                 error:
+ *                   type: string
+ *                   description: Error message
+ *                   example: "Invalid product data"
  */
 router.post(
   "/",
@@ -86,29 +201,68 @@ router.post(
  * @swagger
  * /products/{id}:
  *   put:
- *     summary: Update product details
- *     description: Update product details
- *     security:
- *      - bearerAuth: []
+ *     summary: Update an existing product
+ *     description: Update an existing product
+ *     tags:
+ *       - Products
  *     parameters:
- *      - in: path
- *        name: id
- *        required: true
- *        schema:
- *          type: string
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
  *     requestBody:
+ *       description: Product data to update
  *       required: true
  *       content:
  *         application/json:
  *           schema:
- *             $ref: '#/components/schemas/Product'
+ *             type: object
+ *             properties:
+ *               name:
+ *                 type: string
+ *               description:
+ *                 type: string
+ *               price:
+ *                 type: number
+ *               images:
+ *                 type: array
+ *                 items:
+ *                   type: string
+ *                 maxItems: 5
+ *               category:
+ *                 type: string
+ *               stock:
+ *                 type: integer
  *     responses:
  *       200:
  *         description: Updated product
  *         content:
  *           application/json:
  *             schema:
- *               $ref: '#/components/schemas/Product'
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   description: Indicates whether the request was successful
+ *                   example: true
+ *                 data:
+ *                   $ref: "#/components/schemas/Product"
+ *       400:
+ *         description: Product update failed
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   description: Indicates whether the request was successful
+ *                   example: false
+ *                 error:
+ *                   type: string
+ *                   description: Error message
+ *                   example: "Product update failed"
  */
 router.put("/:id", authenticateToken, checkAdmin, updateProductHandler);
 
@@ -118,17 +272,32 @@ router.put("/:id", authenticateToken, checkAdmin, updateProductHandler);
  *   delete:
  *     summary: Delete a product by ID
  *     description: Delete a product by ID
- *     security:
- *      - bearerAuth: []
+ *     tags:
+ *       - Products
  *     parameters:
- *      - in: path
- *        name: id
- *        required: true
- *        schema:
- *          type: string
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
  *     responses:
  *       204:
- *         description: No content
+ *         description: Product deleted
+ *       400:
+ *         description: Product deletion failed
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   description: Indicates whether the request was successful
+ *                   example: false
+ *                 error:
+ *                   type: string
+ *                   description: Error message
+ *                   example: "Product deletion failed"
  */
 router.delete("/:id", authenticateToken, checkAdmin, deleteProductHandler);
 


### PR DESCRIPTION
This PR refactors the product and user controllers to use only JSDoc and migrates the swagger jsdoc comments to solely the respective routes for cleaner documentation. 

**Changes Included:**

- Swagger documentation for the following routes:  products & authentication
- Documentation accessible at `/api-docs` for contributors
- Standardized response formatting for user and product controllers

**Next steps**
- Document remaining routes with swagger jdsoc i.e admin, order and cart routes
- Standardize response format for the remaining controllers i.e. admin, order and cart controllers