### PR TITLE
Fix/Include product slug in favorites API response

### DIFF
--- a/src/models/favorites.model.js
+++ b/src/models/favorites.model.js
@@ -7,7 +7,7 @@ async function getFavorites(userId) {
   try {
     const user = await User.findById(userId).select("favorites").populate({
       path: "favorites.productId",
-      select: "name price images stock",
+      select: "name price images stock slug",
     });
 
     if (!user) throw new Error("User not found");
@@ -20,6 +20,7 @@ async function getFavorites(userId) {
         price: fav.productId.price,
         images: fav.productId.images,
         stock: fav.productId.stock,
+        slug: fav.productId.slug,
       }));
 
     return transformFavorites;


### PR DESCRIPTION
**Problem:**
The frontend was unable to generate proper product detail page links from favorites data because the `slug` field was missing from the API response. This caused the frontend to fall back to using product IDs instead of slugs for navigation.

**Solution:**
- Added `slug` to the product fields selected in the `getFavorites()` function populate query
- Included `slug` in the transformed favorites response object

This fix ensures that the favorites API returns all necessary data for the frontend to construct proper product detail page links using slugs instead of falling back to product IDs.