### PR TITLE
Fix/ Rate Limiting Configuration Causing Sporadic 429 Errors

### DIFF
--- a/src/routes/payment.routes.js
+++ b/src/routes/payment.routes.js
@@ -3,6 +3,7 @@ import {
   handlePaystackWebhook,
   verifyPayment,
 } from "../controllers/payment.controller.js";
+import { routeLimiters } from "../config/rateLimiter.js";
 
 const router = express.Router();
 
@@ -93,6 +94,6 @@ router.post("/webhook/paystack", handlePaystackWebhook);
  *       500:
  *         description: Server error
  */
-router.get("/verify/:reference", verifyPayment);
+router.get("/verify/:reference", routeLimiters.payment, verifyPayment);
 
 export default router;


### PR DESCRIPTION
## Problem
Production was experiencing sporadic 429 (Too Many Requests) errors that were blocking legitimate user requests and payment webhooks.

### Root Causes
1. Double rate limiting: A global rate limiter (100 req/15min) was applied to all routes, and route-specific limiters were also applied, causing requests to be checked against both limiters
2. Webhook rate limiting: Paystack webhook endpoint was being rate limited, causing payment processing failures
3. Incorrect IP detection: Missing trust proxy configuration meant all requests appeared to come from the same IP when behind Railway's reverse proxy, causing shared rate limit buckets

### Changes
- Removed global rate limiter from app.js to eliminate double limiting
- Added trust proxy configuration (app.set("trust proxy", 1)) to ensure correct client IP detection for rate limiting
- Moved rate limiting from route mount to per-route application in payment.routes.js
- Excluded Paystack webhook endpoint from rate limiting to prevent payment processing failures
- Applied rate limiting to verify endpoint only (10 requests per 15 minutes)
- Added general rate limiter to favorites routes