### PR TITLE
Chore/cors env

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -45,7 +45,8 @@ app.use(
 
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
-app.use(cors(corsOptions(env.NODE_ENV)));
+// CORS: CLIENT_URL + CORS_ORIGINS + Paystack (config passed from env).
+app.use(cors(corsOptions(env)));
 app.use(`${API_PREFIX}/api-docs`, serve, setup(swaggerSpec));
 
 app.get("/", (req, res) => {

--- a/src/config/cors.js
+++ b/src/config/cors.js
@@ -1,43 +1,29 @@
-const allowedOrigins = {
-  development: [
-    "http://localhost:3000",
-    "https://www.misqabbigh.com",
-    "https://misqabbigh.com",
-    "https://development--misqabbigh.netlify.app",
-    "https://misqabbigh.netlify.app",
-    "https://checkout.paystack.com",
-    "https://api.paystack.co",
-  ],
-  staging: [
-    "https://misqabbigh.netlify.app",
-    "https://staging--misqabbigh.netlify.app",
-    "https://misqabbigh.com",
-    "https://www.misqabbigh.com",
-    "https://checkout.paystack.com",
-    "https://api.paystack.co",
-  ],
-  production: [
-    "https://shop.misqabbigh.com",
-    "https://www.misqabbigh.com",
-    "https://misqabbigh.com",
-    "https://misqabbigh.netlify.app",
-    "https://checkout.paystack.com",
-    "https://api.paystack.co",
-  ],
-};
+// Allowed origins = CLIENT_URL + CORS_ORIGINS (comma-separated) + Paystack.
+// Config is passed from app.js so this file stays testable and has no env dependency.
+const PAYSTACK_ORIGINS = [
+  "https://checkout.paystack.com",
+  "https://api.paystack.co",
+];
 
-const corsOptions = env => {
-  const whitelist = allowedOrigins[env] || [];
+function parseOrigins(value) {
+  if (!value || typeof value !== "string") return [];
+  return value
+    .split(",")
+    .map(s => s.trim())
+    .filter(Boolean);
+}
+
+/**
+ * @param {{ CLIENT_URL: string, CORS_ORIGINS?: string }} config - Env config from app.
+ */
+const corsOptions = config => {
+  const extra = parseOrigins(config.CORS_ORIGINS);
+  const whitelist = [
+    ...new Set([config.CLIENT_URL, ...extra, ...PAYSTACK_ORIGINS]),
+  ];
+
   return {
-    /**
-     * CORS origin function to check if the incoming request's origin is
-     * allowed to make requests to the server.
-     *
-     * @param {string} origin - The origin of the incoming request.
-     * @param {Function} callback - Called with either `null` or an `Error`
-     *   object indicating whether the request is allowed or not.
-     */
-    origin: function (origin, callback) {
+    origin(origin, callback) {
       if (!origin || whitelist.includes(origin)) {
         callback(null, true);
       } else {

--- a/src/config/env.js
+++ b/src/config/env.js
@@ -45,6 +45,9 @@ const baseSchema = {
     default: "local",
   }),
 
+  /** Extra CORS origins, comma-separated (e.g. "https://a.com,https://b.com"). */
+  CORS_ORIGINS: str({ default: "" }),
+
   // Redis configuration
   REDIS_URL: str({ default: "" }),
   REDIS_HOST: str({ default: "localhost" }),


### PR DESCRIPTION
## Summary

This branch refactors CORS to be fully env-driven.

## CORS Refactor

**Problem:** Hardcoded origin lists per `NODE_ENV` caused staging (e.g. Railway with `NODE_ENV=production`) to reject the staging frontend origin.

**Solution:** Allowed origins are now built from env only:

- **CLIENT_URL** — Primary frontend origin (set per deployment: e.g. `https://staging--misqabbigh.netlify.app` for staging API).
- **CORS_ORIGINS** — Optional comma-separated list for extra origins (e.g. `https://www.misqabbigh.com,https://misqabbigh.com`).
- Paystack origins remain in code and are always included.

**Changes:**

- `src/config/cors.js` — Removed env-keyed hardcoded lists. `corsOptions(config)` now takes a config object (CLIENT_URL, CORS_ORIGINS), parses CORS_ORIGINS, and builds a single whitelist. No import of env; config is passed from app for testability and to avoid circular dependencies.
- `src/config/env.js` — Added optional `CORS_ORIGINS` (string, default `""`).
- `src/app.js` — Calls `cors(corsOptions(env))` so env is the single source of config.

**Deployment:** Set `CLIENT_URL` to the frontend origin for that environment. Set `CORS_ORIGINS` only if you need additional origins (e.g. alternate domains).

## Configuration

- **CORS:** Ensure `CLIENT_URL` (and optionally `CORS_ORIGINS`) is set per environment so the correct frontend origin(s) are allowed.
