### PR TITLE
Feature/guest checkout

### DIFF
--- a/server.js
+++ b/server.js
@@ -4,6 +4,7 @@ import http from "node:http";
 import app from "./src/app.js";
 
 import { mongoConnect } from "./src/services/mongo.js";
+import { scheduleGuestCleanup } from "./src/services/guestCleanupService.js";
 import logger from "./src/config/logger.js";
 
 const PORT = env.PORT || 5000;
@@ -25,6 +26,7 @@ async function startServer() {
     const server = http.createServer(app);
     server.listen(PORT, () => {
       console.log(`Server running at http://localhost:${PORT}`);
+      scheduleGuestCleanup();
     });
   } catch (error) {
     logger.error("Server startup failed:", {

--- a/src/config/env.js
+++ b/src/config/env.js
@@ -22,6 +22,7 @@ const baseSchema = {
   JWT_EXPIRES_IN: num(),
   ACCESS_TOKEN_EXPIRES_IN: num({ default: 900 }), // 15 minutes
   REFRESH_TOKEN_EXPIRES_IN: num({ default: 604800 }), // 7 days
+  GUEST_TOKEN_EXPIRES_IN: num({ default: 2592000 }), // 30 days
   GOOGLE_CLIENT_ID: str(),
   GOOGLE_CLIENT_SECRET: str(),
   GOOGLE_CALLBACK_URL: url(),

--- a/src/config/rateLimiter.js
+++ b/src/config/rateLimiter.js
@@ -63,6 +63,7 @@ export const rateLimiters = {
 // Route-specific limiters (can be customized further if needed)
 export const routeLimiters = {
   auth: rateLimiters.strict, // 10 requests
+  guestSession: rateLimiters.veryStrict, // 5 requests
   newsletter: rateLimiters.veryStrict, // 5 requests
   order: rateLimiters.strict, // 10 requests
   payment: rateLimiters.strict, // 10 requests

--- a/src/controllers/orders.controller.js
+++ b/src/controllers/orders.controller.js
@@ -347,7 +347,7 @@ export const initializeCheckout = async (req, res) => {
 };
 
 export const getOrders = async (req, res) => {
-  const userId = req.user._id;
+  const userId = req.principal?._id;
   const page = Number(req.query.page) || 1;
   const limit = Number(req.query.limit) || 10;
   try {
@@ -370,7 +370,7 @@ export const getOrders = async (req, res) => {
 };
 
 export const getOrderById = async (req, res) => {
-  const userId = req.user._id;
+  const userId = req.principal?._id;
   const orderId = req.params.id;
   try {
     const order = await fetchOrderById(orderId, userId);

--- a/src/controllers/orders.controller.js
+++ b/src/controllers/orders.controller.js
@@ -33,7 +33,8 @@ function parseBooleanQueryParam(value, defaultValue = false) {
 
 export const initializeCheckout = async (req, res) => {
   const { items, shippingInfo, discountCode } = req.body;
-  const userId = req.user._id;
+  const principal = req.principal;
+  const userId = principal?._id;
 
   // Parse expressService from query parameter (defaults to false)
   const expressService = parseBooleanQueryParam(
@@ -288,8 +289,20 @@ export const initializeCheckout = async (req, res) => {
     const transaction = await createTransaction(transactionData);
 
     // Initialize the Paystack transaction
+    const payerEmail =
+      principal?.type === "user" ? req.user?.email : shippingInfo?.email;
+
+    if (!payerEmail) {
+      return res.status(400).json(
+        formatResponse({
+          success: false,
+          error: "A valid email is required to initialize payment",
+        })
+      );
+    }
+
     const paystackResponse = await initializeTransaction(
-      req.user.email,
+      payerEmail,
       amountInPesewas,
       {
         userId: userId.toString(),

--- a/src/controllers/payment.controller.js
+++ b/src/controllers/payment.controller.js
@@ -16,6 +16,15 @@ import { recordUsage } from "../models/discountUsage.model.js";
 import logger from "../config/logger.js";
 import { formatResponse } from "../utils/responseFormatter.js";
 
+function isTransactionOwnedByPrincipal(transaction, principalId) {
+  if (!transaction || !principalId) return false;
+  const txUserId =
+    typeof transaction.user === "object" && transaction.user?._id
+      ? transaction.user._id.toString()
+      : transaction.user?.toString();
+  return txUserId === principalId.toString();
+}
+
 /**
  * Handle Paystack webhook events
  * @param {Object} req - Express request object
@@ -254,6 +263,7 @@ async function handleFailedPayment(data) {
 export const verifyPayment = async (req, res) => {
   try {
     const { reference } = req.params;
+    const principalId = req.principal?._id;
 
     if (!reference) {
       return res.status(400).json(
@@ -276,6 +286,15 @@ export const verifyPayment = async (req, res) => {
       );
     }
 
+    if (!isTransactionOwnedByPrincipal(transaction, principalId)) {
+      return res.status(403).json(
+        formatResponse({
+          success: false,
+          error: "Access denied for this transaction",
+        })
+      );
+    }
+
     // If transaction is still pending, verify with Paystack
     if (transaction.status === "pending") {
       try {
@@ -291,6 +310,14 @@ export const verifyPayment = async (req, res) => {
 
           // Refetch transaction to get updated data
           const updatedTransaction = await getTransactionByReference(reference);
+          if (!isTransactionOwnedByPrincipal(updatedTransaction, principalId)) {
+            return res.status(403).json(
+              formatResponse({
+                success: false,
+                error: "Access denied for this transaction",
+              })
+            );
+          }
           return res.status(200).json(
             formatResponse({
               message: "Payment verified successfully",

--- a/src/controllers/users.controller.js
+++ b/src/controllers/users.controller.js
@@ -17,11 +17,14 @@ import {
 import { formatResponse } from "../utils/responseFormatter.js";
 import {
   getAccessTokenCookieOptions,
+  getGuestTokenCookieOptions,
   getRefreshTokenCookieOptions,
 } from "../utils/getCookieOptions.js";
 
 import {
   createLocalUser,
+  createGuestUser,
+  findActiveGuestUserById,
   findUserByEmail,
   findUserById,
   getPaginatedUsers,
@@ -29,6 +32,8 @@ import {
   deleteUserById,
   updateUserRole,
 } from "../models/user.model.js";
+import { signGuestToken, verifyGuestToken } from "../services/jwtService.js";
+import { mergeGuestIntoUser } from "../services/guestMergeService.js";
 import ResetToken from "../models/resetToken.mongo.js";
 
 import { PASSWORD_RESET_EMAIL } from "../constants/emailTemplates.js";
@@ -68,6 +73,60 @@ export async function registerUser(req, res) {
       formatResponse({
         success: false,
         message: "Failed to register user",
+      })
+    );
+  }
+}
+
+/**
+ * @route   POST /auth/guest/session
+ * @desc    Creates or refreshes an anonymous guest session
+ * @access  Public
+ */
+export async function createGuestSession(req, res) {
+  try {
+    const guestCookie = req.cookies?.guest_token;
+    const guestCookieOptions = getGuestTokenCookieOptions();
+
+    if (guestCookie) {
+      try {
+        const payload = verifyGuestToken(guestCookie);
+        const existingGuest = await findActiveGuestUserById(payload.id);
+        if (existingGuest) {
+          existingGuest.guestLastSeenAt = new Date();
+          await existingGuest.save();
+          const refreshedToken = signGuestToken({ id: existingGuest._id });
+          res.cookie("guest_token", refreshedToken, guestCookieOptions);
+          return res.status(200).json(
+            formatResponse({
+              message: "Guest session refreshed",
+              data: { guestId: existingGuest._id },
+            })
+          );
+        }
+      } catch (error) {
+        logger.warn(
+          `[createGuestSession] Invalid existing guest token: ${error.message}`
+        );
+      }
+    }
+
+    const guestUser = await createGuestUser();
+    const guestToken = signGuestToken({ id: guestUser._id });
+    res.cookie("guest_token", guestToken, guestCookieOptions);
+
+    return res.status(201).json(
+      formatResponse({
+        message: "Guest session created",
+        data: { guestId: guestUser._id },
+      })
+    );
+  } catch (error) {
+    logger.error(`[createGuestSession] ${error.message}`);
+    return res.status(500).json(
+      formatResponse({
+        success: false,
+        message: "Failed to create guest session",
       })
     );
   }
@@ -198,6 +257,24 @@ export async function getCurrentUser(req, res) {
  */
 async function finalizeAuth(req, res) {
   try {
+    const guestCookie = req.cookies?.guest_token;
+    if (guestCookie) {
+      try {
+        const decodedGuest = verifyGuestToken(guestCookie);
+        const mergeResult = await mergeGuestIntoUser(
+          decodedGuest.id,
+          req.user._id
+        );
+        logger.info(
+          `[finalizeAuth] Guest merge result for user ${req.user._id}: ${JSON.stringify(mergeResult)}`
+        );
+      } catch (error) {
+        logger.warn(`[finalizeAuth] Guest merge skipped: ${error.message}`);
+      } finally {
+        res.clearCookie("guest_token", getGuestTokenCookieOptions());
+      }
+    }
+
     // Generate tokens
     const accessToken = signAccessToken({
       id: req.user._id,

--- a/src/middleware/auth.middleware.js
+++ b/src/middleware/auth.middleware.js
@@ -1,6 +1,14 @@
 import { verifyToken } from "../services/jwtService.js";
-import { findUserById } from "../models/user.model.js";
-import { getAccessTokenCookieOptions } from "../utils/getCookieOptions.js";
+import { verifyGuestToken } from "../services/jwtService.js";
+import {
+  findUserById,
+  findActiveGuestUserById,
+  touchGuestLastSeen,
+} from "../models/user.model.js";
+import {
+  getAccessTokenCookieOptions,
+  getGuestTokenCookieOptions,
+} from "../utils/getCookieOptions.js";
 import logger from "../config/logger.js";
 
 /**
@@ -45,6 +53,56 @@ async function authenticateToken(req, res, next) {
 }
 
 /**
+ * Resolves request principal as either authenticated user or guest user.
+ * - Prefers authenticated user token when present and valid.
+ * - Falls back to guest token for anonymous checkout-capable flows.
+ */
+async function authenticateOptionalPrincipal(req, res, next) {
+  const authToken = req.cookies?.auth_token;
+  const guestToken = req.cookies?.guest_token;
+
+  if (authToken) {
+    try {
+      const decoded = verifyToken(authToken);
+      const user = await findUserById(decoded.id);
+      if (user) {
+        req.user = user;
+        req.principal = { type: "user", _id: user._id, user };
+        return next();
+      }
+      res.clearCookie("auth_token", getAccessTokenCookieOptions());
+    } catch (error) {
+      logger.warn(
+        `[auth.middleware] Optional principal auth token invalid: ${error.message}`
+      );
+      res.clearCookie("auth_token", getAccessTokenCookieOptions());
+    }
+  }
+
+  if (guestToken) {
+    try {
+      const decodedGuest = verifyGuestToken(guestToken);
+      const guest = await findActiveGuestUserById(decodedGuest.id);
+      if (guest) {
+        await touchGuestLastSeen(guest._id);
+        req.principal = { type: "guest", _id: guest._id, user: guest };
+        return next();
+      }
+      res.clearCookie("guest_token", getGuestTokenCookieOptions());
+    } catch (error) {
+      logger.warn(
+        `[auth.middleware] Optional principal guest token invalid: ${error.message}`
+      );
+      res.clearCookie("guest_token", getGuestTokenCookieOptions());
+    }
+  }
+
+  return res
+    .status(401)
+    .json({ message: "Authentication or guest session required" });
+}
+
+/**
  * Middleware to restrict access to admin-only routes.
  *
  * Assumes req.user is populated by authentication middleware
@@ -57,4 +115,4 @@ function checkAdmin(req, res, next) {
   next();
 }
 
-export { authenticateToken, checkAdmin };
+export { authenticateToken, authenticateOptionalPrincipal, checkAdmin };

--- a/src/middleware/index.js
+++ b/src/middleware/index.js
@@ -1,4 +1,13 @@
-import { authenticateToken, checkAdmin } from "./auth.middleware.js";
+import {
+  authenticateToken,
+  authenticateOptionalPrincipal,
+  checkAdmin,
+} from "./auth.middleware.js";
 import errorHandler from "./error.middleware.js";
 
-export { authenticateToken, checkAdmin, errorHandler };
+export {
+  authenticateToken,
+  authenticateOptionalPrincipal,
+  checkAdmin,
+  errorHandler,
+};

--- a/src/models/discountUsage.model.js
+++ b/src/models/discountUsage.model.js
@@ -123,6 +123,25 @@ export async function getUsageByUser(userId, page = 1, limit = 20) {
   }
 }
 
+export async function reassignDiscountUsageToUser(
+  fromUserId,
+  toUserId,
+  session = null
+) {
+  try {
+    const query = { user: fromUserId };
+    const update = { user: toUserId };
+    const options = session ? { session } : {};
+    const result = await DiscountUsage.updateMany(query, update, options);
+    return result?.modifiedCount || 0;
+  } catch (error) {
+    logger.error(
+      `[discountUsage.model] Error reassigning usage from ${fromUserId} to ${toUserId}: ${error.message}`
+    );
+    throw error;
+  }
+}
+
 /**
  * Link an order to an existing usage record.
  * Used after payment is confirmed.

--- a/src/models/order.model.js
+++ b/src/models/order.model.js
@@ -164,6 +164,25 @@ export async function getOrdersByUser(userId) {
   }
 }
 
+export async function reassignOrdersToUser(
+  fromUserId,
+  toUserId,
+  session = null
+) {
+  try {
+    const query = { user: fromUserId };
+    const update = { user: toUserId };
+    const options = session ? { session } : {};
+    const result = await Order.updateMany(query, update, options);
+    return result?.modifiedCount || 0;
+  } catch (error) {
+    logger.error(
+      `[order.model] Error reassigning orders from ${fromUserId} to ${toUserId}: ${error.message}`
+    );
+    throw error;
+  }
+}
+
 export async function getPaginatedOrdersByUser(userId, page, limit) {
   try {
     const skip = (page - 1) * limit;

--- a/src/models/transaction.model.js
+++ b/src/models/transaction.model.js
@@ -96,6 +96,25 @@ export async function countTransactionsByUser(userId) {
   }
 }
 
+export async function reassignTransactionsToUser(
+  fromUserId,
+  toUserId,
+  session = null
+) {
+  try {
+    const query = { user: fromUserId };
+    const update = { user: toUserId };
+    const options = session ? { session } : {};
+    const result = await Transaction.updateMany(query, update, options);
+    return result?.modifiedCount || 0;
+  } catch (error) {
+    logger.error(
+      `[transaction.model] Error reassigning transactions from ${fromUserId} to ${toUserId}: ${error.message}`
+    );
+    throw error;
+  }
+}
+
 export async function getTransactionById(transactionId, userId) {
   try {
     const transaction = await Transaction.findOne({

--- a/src/models/user.model.js
+++ b/src/models/user.model.js
@@ -37,6 +37,24 @@ async function createGoogleUser({ email, googleId, displayName }) {
 }
 
 /**
+ * Create a lightweight guest user for anonymous checkout.
+ *
+ * @returns {Promise<Object>} - Newly created guest user document
+ */
+async function createGuestUser() {
+  try {
+    const user = new User({
+      isGuest: true,
+      guestLastSeenAt: new Date(),
+    });
+    return await user.save();
+  } catch (error) {
+    logger.error(`[users.model] Error creating guest user: ${error.message}`);
+    throw error;
+  }
+}
+
+/**
  * Find a user by their email address.
  *
  * @param {string} email - Email to search for
@@ -78,7 +96,86 @@ async function findUserById(id) {
   }
 }
 
-export { createLocalUser, createGoogleUser, findUserByEmail, findUserById };
+/**
+ * Find an active (unmerged) guest user by ID.
+ *
+ * @param {string|ObjectId} id - Guest user ID
+ * @returns {Promise<Object|null>} - Guest user or null
+ */
+async function findActiveGuestUserById(id) {
+  try {
+    if (typeof id !== "string" && !Types.ObjectId.isValid(id)) {
+      logger.warn(`[users.model] Invalid guest ID format: ${id}`);
+      return null;
+    }
+    return await User.findOne({
+      _id: id,
+      isGuest: true,
+      guestMergedInto: null,
+    });
+  } catch (error) {
+    logger.error(
+      `[users.model] Error finding active guest by id ${id}: ${error.message}`
+    );
+    throw error;
+  }
+}
+
+/**
+ * Touch guest activity timestamp.
+ *
+ * @param {string|ObjectId} guestUserId - Guest user ID
+ * @returns {Promise<Object|null>} - Updated guest document or null
+ */
+async function touchGuestLastSeen(guestUserId) {
+  try {
+    if (!Types.ObjectId.isValid(guestUserId)) return null;
+    return await User.findOneAndUpdate(
+      { _id: guestUserId, isGuest: true, guestMergedInto: null },
+      { guestLastSeenAt: new Date() },
+      { new: true }
+    );
+  } catch (error) {
+    logger.error(
+      `[users.model] Error touching guest last seen ${guestUserId}: ${error.message}`
+    );
+    throw error;
+  }
+}
+
+/**
+ * Deletes stale unmerged guest users inactive before provided cutoff.
+ *
+ * @param {Date} cutoffDate - Guests last seen before this date are deleted
+ * @returns {Promise<number>} - Number of deleted guests
+ */
+async function deleteStaleGuests(cutoffDate) {
+  try {
+    const result = await User.deleteMany({
+      isGuest: true,
+      guestMergedInto: null,
+      $or: [
+        { guestLastSeenAt: { $lt: cutoffDate } },
+        { guestLastSeenAt: null, createdAt: { $lt: cutoffDate } },
+      ],
+    });
+    return result?.deletedCount || 0;
+  } catch (error) {
+    logger.error(`[users.model] Error deleting stale guests: ${error.message}`);
+    throw error;
+  }
+}
+
+export {
+  createLocalUser,
+  createGoogleUser,
+  createGuestUser,
+  findUserByEmail,
+  findUserById,
+  findActiveGuestUserById,
+  touchGuestLastSeen,
+  deleteStaleGuests,
+};
 
 // Admin listing helpers
 export async function getPaginatedUsers(page = 1, limit = 10, params = {}) {

--- a/src/models/user.mongo.js
+++ b/src/models/user.mongo.js
@@ -62,7 +62,7 @@ const userSchema = new Schema(
     password: {
       type: String,
       required: function () {
-        return !this.googleId;
+        return !this.isGuest && !this.googleId;
       },
       validate: {
         validator: function (value) {

--- a/src/models/user.mongo.js
+++ b/src/models/user.mongo.js
@@ -37,6 +37,11 @@ const favoriteItemSchema = new Schema(
  */
 const userSchema = new Schema(
   {
+    isGuest: {
+      type: Boolean,
+      default: false,
+      index: true,
+    },
     displayName: {
       type: String,
       trim: true,
@@ -44,8 +49,9 @@ const userSchema = new Schema(
     },
     email: {
       type: String,
-      required: true,
-      unique: true,
+      required: function () {
+        return !this.isGuest;
+      },
       lowercase: true,
       trim: true,
       match: EMAIL_REGEX,
@@ -74,6 +80,15 @@ const userSchema = new Schema(
     contact: { type: String },
     location: { type: String },
     profileComplete: { type: Boolean, default: false },
+    guestMergedInto: {
+      type: Schema.Types.ObjectId,
+      ref: "User",
+      default: null,
+    },
+    guestLastSeenAt: {
+      type: Date,
+      default: null,
+    },
 
     favorites: [favoriteItemSchema], // Embedded for fast access and frequent updates
     previousOrders: [
@@ -90,6 +105,15 @@ const userSchema = new Schema(
 userSchema.index(
   { displayName: "text", email: "text" },
   { name: "UserTextIndex" }
+);
+// Keep email unique for real users while allowing many guest users without email.
+userSchema.index(
+  { email: 1 },
+  {
+    unique: true,
+    name: "UniqueEmailForAccountUsers",
+    partialFilterExpression: { isGuest: false },
+  }
 );
 
 /**

--- a/src/routes/auth.routes.js
+++ b/src/routes/auth.routes.js
@@ -3,6 +3,7 @@ import passport from "passport";
 
 import {
   forgotPassword,
+  createGuestSession,
   getCurrentUser,
   handleGoogleCallback,
   handleAuthSuccess,
@@ -105,6 +106,21 @@ const hydrateLimiter = createRateLimiter(200, {
  *                   description: Error message
  */
 router.post("/signup", routeLimiters.auth, validateUser, registerUser);
+/**
+ * @swagger
+ * /auth/guest/session:
+ *   post:
+ *     summary: Create or refresh anonymous guest session
+ *     description: Creates a guest identity for anonymous checkout or refreshes an existing guest session cookie.
+ *     tags:
+ *       - Users
+ *     responses:
+ *       200:
+ *         description: Guest session refreshed
+ *       201:
+ *         description: Guest session created
+ */
+router.post("/guest/session", routeLimiters.guestSession, createGuestSession);
 
 /**
  * @swagger

--- a/src/routes/orders.routes.js
+++ b/src/routes/orders.routes.js
@@ -1,8 +1,5 @@
 import express from "express";
-import {
-  authenticateOptionalPrincipal,
-  authenticateToken,
-} from "../middleware/index.js";
+import { authenticateOptionalPrincipal } from "../middleware/index.js";
 import {
   initializeCheckout,
   getOrders,
@@ -160,7 +157,7 @@ router.post(
  *               totalPages: 0
  *               currentPage: 1
  */
-router.get("/", authenticateToken, getOrders);
+router.get("/", authenticateOptionalPrincipal, getOrders);
 
 /**
  * @swagger
@@ -203,6 +200,6 @@ router.get("/", authenticateToken, getOrders);
  *                     quantity: 1
  *                     price: 100
  */
-router.get("/:id", authenticateToken, getOrderById);
+router.get("/:id", authenticateOptionalPrincipal, getOrderById);
 
 export default router;

--- a/src/routes/orders.routes.js
+++ b/src/routes/orders.routes.js
@@ -1,5 +1,8 @@
 import express from "express";
-import { authenticateToken } from "../middleware/index.js";
+import {
+  authenticateOptionalPrincipal,
+  authenticateToken,
+} from "../middleware/index.js";
 import {
   initializeCheckout,
   getOrders,
@@ -19,6 +22,7 @@ const router = express.Router();
  *       - Orders
  *     security:
  *       - bearerAuth: []
+ *     description: Supports authenticated users and valid guest sessions.
  *     parameters:
  *       - in: query
  *         name: expressService
@@ -98,7 +102,12 @@ const router = express.Router();
  *       500:
  *         description: Server error
  */
-router.post("/checkout", validateOrder, authenticateToken, initializeCheckout);
+router.post(
+  "/checkout",
+  validateOrder,
+  authenticateOptionalPrincipal,
+  initializeCheckout
+);
 
 /**
  * @swagger

--- a/src/routes/orders.routes.js
+++ b/src/routes/orders.routes.js
@@ -22,7 +22,6 @@ const router = express.Router();
  *       - Orders
  *     security:
  *       - bearerAuth: []
- *     description: Supports authenticated users and valid guest sessions.
  *     parameters:
  *       - in: query
  *         name: expressService

--- a/src/routes/payment.routes.js
+++ b/src/routes/payment.routes.js
@@ -4,6 +4,7 @@ import {
   verifyPayment,
 } from "../controllers/payment.controller.js";
 import { routeLimiters } from "../config/rateLimiter.js";
+import { authenticateOptionalPrincipal } from "../middleware/index.js";
 
 const router = express.Router();
 
@@ -54,7 +55,7 @@ router.post("/webhook/paystack", handlePaystackWebhook);
  * /payment/verify/{reference}:
  *   get:
  *     summary: Verify payment status
- *     description: Manually verify payment status for a given transaction reference. Useful for frontend payment confirmation.
+ *     description: Manually verify payment status for a given transaction reference. Access is restricted to the owning authenticated user or guest session.
  *     tags:
  *       - Payment
  *     security:
@@ -94,6 +95,11 @@ router.post("/webhook/paystack", handlePaystackWebhook);
  *       500:
  *         description: Server error
  */
-router.get("/verify/:reference", routeLimiters.payment, verifyPayment);
+router.get(
+  "/verify/:reference",
+  routeLimiters.payment,
+  authenticateOptionalPrincipal,
+  verifyPayment
+);
 
 export default router;

--- a/src/services/guestCleanupService.js
+++ b/src/services/guestCleanupService.js
@@ -1,0 +1,30 @@
+import logger from "../config/logger.js";
+import { deleteStaleGuests } from "../models/user.model.js";
+
+const GUEST_RETENTION_DAYS = 30;
+const CLEANUP_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+export async function runGuestCleanup() {
+  const cutoffDate = new Date(
+    Date.now() - GUEST_RETENTION_DAYS * CLEANUP_INTERVAL_MS
+  );
+  const deletedCount = await deleteStaleGuests(cutoffDate);
+  logger.info(
+    `[guestCleanupService] Deleted ${deletedCount} stale guest users before ${cutoffDate.toISOString()}`
+  );
+  return deletedCount;
+}
+
+export function scheduleGuestCleanup() {
+  const execute = async () => {
+    try {
+      await runGuestCleanup();
+    } catch (error) {
+      logger.error(`[guestCleanupService] Cleanup failed: ${error.message}`);
+    }
+  };
+
+  execute();
+  const timer = setInterval(execute, CLEANUP_INTERVAL_MS);
+  return timer;
+}

--- a/src/services/guestMergeService.js
+++ b/src/services/guestMergeService.js
@@ -1,0 +1,71 @@
+import mongoose from "mongoose";
+import User from "../models/user.mongo.js";
+import { reassignOrdersToUser } from "../models/order.model.js";
+import { reassignTransactionsToUser } from "../models/transaction.model.js";
+import { reassignDiscountUsageToUser } from "../models/discountUsage.model.js";
+import logger from "../config/logger.js";
+
+export async function mergeGuestIntoUser(guestUserId, realUserId) {
+  if (!guestUserId || !realUserId) {
+    return { merged: false, reason: "missing_ids" };
+  }
+
+  if (guestUserId.toString() === realUserId.toString()) {
+    return { merged: false, reason: "same_identity" };
+  }
+
+  const session = await mongoose.startSession();
+  session.startTransaction();
+
+  try {
+    const [guestUser, realUser] = await Promise.all([
+      User.findById(guestUserId).session(session),
+      User.findById(realUserId).session(session),
+    ]);
+
+    if (!realUser) {
+      await session.abortTransaction();
+      return { merged: false, reason: "real_user_not_found" };
+    }
+
+    if (!guestUser || !guestUser.isGuest) {
+      await session.abortTransaction();
+      return { merged: false, reason: "guest_not_found" };
+    }
+
+    if (guestUser.guestMergedInto) {
+      await session.abortTransaction();
+      return { merged: false, reason: "already_merged" };
+    }
+
+    const [ordersMoved, transactionsMoved, discountUsageMoved] =
+      await Promise.all([
+        reassignOrdersToUser(guestUser._id, realUser._id, session),
+        reassignTransactionsToUser(guestUser._id, realUser._id, session),
+        reassignDiscountUsageToUser(guestUser._id, realUser._id, session),
+      ]);
+
+    guestUser.guestMergedInto = realUser._id;
+    guestUser.guestLastSeenAt = new Date();
+    await guestUser.save({ session });
+
+    await session.commitTransaction();
+
+    logger.info(
+      `[guestMergeService] Merged guest ${guestUserId} into user ${realUserId}. Orders: ${ordersMoved}, Transactions: ${transactionsMoved}, DiscountUsage: ${discountUsageMoved}`
+    );
+
+    return {
+      merged: true,
+      ordersMoved,
+      transactionsMoved,
+      discountUsageMoved,
+    };
+  } catch (error) {
+    await session.abortTransaction();
+    logger.error(`[guestMergeService] Merge failed: ${error.message}`);
+    throw error;
+  } finally {
+    session.endSession();
+  }
+}

--- a/src/services/guestMergeService.js
+++ b/src/services/guestMergeService.js
@@ -18,10 +18,9 @@ export async function mergeGuestIntoUser(guestUserId, realUserId) {
   session.startTransaction();
 
   try {
-    const [guestUser, realUser] = await Promise.all([
-      User.findById(guestUserId).session(session),
-      User.findById(realUserId).session(session),
-    ]);
+    // Sequential reads: MongoDB sessions must not run concurrent ops in a transaction.
+    const guestUser = await User.findById(guestUserId).session(session);
+    const realUser = await User.findById(realUserId).session(session);
 
     if (!realUser) {
       await session.abortTransaction();
@@ -38,12 +37,22 @@ export async function mergeGuestIntoUser(guestUserId, realUserId) {
       return { merged: false, reason: "already_merged" };
     }
 
-    const [ordersMoved, transactionsMoved, discountUsageMoved] =
-      await Promise.all([
-        reassignOrdersToUser(guestUser._id, realUser._id, session),
-        reassignTransactionsToUser(guestUser._id, realUser._id, session),
-        reassignDiscountUsageToUser(guestUser._id, realUser._id, session),
-      ]);
+    // Sequential writes: same session cannot be used in parallel inside a transaction.
+    const ordersMoved = await reassignOrdersToUser(
+      guestUser._id,
+      realUser._id,
+      session
+    );
+    const transactionsMoved = await reassignTransactionsToUser(
+      guestUser._id,
+      realUser._id,
+      session
+    );
+    const discountUsageMoved = await reassignDiscountUsageToUser(
+      guestUser._id,
+      realUser._id,
+      session
+    );
 
     guestUser.guestMergedInto = realUser._id;
     guestUser.guestLastSeenAt = new Date();

--- a/src/services/jwtService.js
+++ b/src/services/jwtService.js
@@ -17,4 +17,20 @@ function verifyToken(token) {
   return jwt.verify(token, env.JWT_SECRET);
 }
 
-export { signToken, signAccessToken, verifyToken };
+function signGuestToken(payload) {
+  return jwt.sign(payload, env.JWT_SECRET, {
+    expiresIn: Number(env.GUEST_TOKEN_EXPIRES_IN) || 30 * 24 * 60 * 60,
+  });
+}
+
+function verifyGuestToken(token) {
+  return jwt.verify(token, env.JWT_SECRET);
+}
+
+export {
+  signToken,
+  signAccessToken,
+  verifyToken,
+  signGuestToken,
+  verifyGuestToken,
+};

--- a/src/utils/getCookieOptions.js
+++ b/src/utils/getCookieOptions.js
@@ -49,3 +49,15 @@ export function getRefreshTokenCookieOptions() {
       Number(env.REFRESH_TOKEN_EXPIRES_IN) * 1000 || 7 * 24 * 60 * 60 * 1000, // 7 days
   };
 }
+
+export function getGuestTokenCookieOptions() {
+  const opts = resolveOpts();
+  return {
+    httpOnly: true,
+    secure: opts.secure,
+    sameSite: opts.sameSite,
+    domain: opts.domain,
+    maxAge:
+      Number(env.GUEST_TOKEN_EXPIRES_IN) * 1000 || 30 * 24 * 60 * 60 * 1000,
+  };
+}


### PR DESCRIPTION
# Guest Checkout MVP

## Summary
- Introduces secure guest sessions to reduce checkout friction without changing the existing `Order.user` and `Transaction.user` ownership model.
- Enables checkout and payment verification for both authenticated users and guest principals.
- Adds transactional guest-to-user merge so guest order history appears after signup/login.
- Adds 30-day stale guest cleanup and guest-specific rate limiting to control abuse and storage growth.

## Problem
Checkout currently requires authentication, creating login friction and drop-off before payment. The commerce model is deeply user-linked, so a full guest model refactor would be high risk.

## Design Decisions
- Keep existing ownership model (`Order.user` and `Transaction.user` stay required).
- Represent anonymous shoppers as lightweight guest users (`isGuest: true`).
- Use HttpOnly guest cookie (`guest_token`) as identity authority.
- Keep favorites account-only to minimize storage and refactor scope.
- Use 30-day retention for unmerged guest identities.

## Key Changes

### Auth and Identity
- Added guest session endpoint: `POST /auth/guest/session`.
- Added guest token cookie options and token helpers.
- Added optional principal middleware that resolves either authenticated user or guest.

### Checkout and Payment
- Checkout now accepts optional principal instead of authenticated user only.
- Checkout payment initialization uses account email for authenticated users and shipping email for guests.
- Payment verify endpoint now enforces transaction ownership checks.
- Order read endpoints now support both authenticated and guest principals with ownership-scoped access for tracking.

### Guest Merge Continuity
- Added transactional merge service to reassign:
  - Orders
  - Transactions
  - Discount usage records
- Merge is idempotent and invoked during auth finalization.
- Merge uses **sequential** reads/writes on the MongoDB session (no `Promise.all` on the same session inside a transaction), matching driver rules and avoiding “transaction number does not match any in-progress transactions” errors.

### Retention and Abuse Controls
- Added guest session rate limiter.
- Added scheduled stale guest cleanup (30-day inactivity window).
- Guest `lastSeen` is refreshed on active guest requests.

## Security Considerations
- Guest identity is not trusted from local storage; authority remains server-verified cookie token.
- Payment verification now denies cross-principal transaction access.
- Guest sessions and checkout paths have dedicated throttling.

## Test Plan
- On upgraded databases: confirm legacy `email_1` is absent (or dropped) so multiple `POST /auth/guest/session` calls succeed.
- Verify guest session creation and refresh behavior.
- Verify guest checkout initializes payment successfully.
- Verify payment verification denies non-owner principals.
- Verify guest-to-user merge reassignment and idempotent behavior.
- Verify stale guest cleanup removes only inactive, unmerged guests.

## Database migration

Guest users omit `email` (stored as `null`). The schema adds a **partial** unique index `UniqueEmailForAccountUsers` on `{ email: 1 }` with `partialFilterExpression: { isGuest: false }`, so many guests can coexist.

**If `POST /auth/guest/session` fails with** `E11000 duplicate key error ... index: email_1 dup key: { email: null }`, the collection still has a **legacy unique index** named `email_1` (or any non-partial unique index on `email`) from before this change. That index allows only **one** document with a null/missing email.

**Fix (one-time per environment):**

1. Inspect indexes: `db.users.getIndexes()` (or MongoDB Compass).
2. If an index named `email_1` (or another full unique index on `email`) exists **in addition to** `UniqueEmailForAccountUsers`, drop the legacy index, e.g. `db.users.dropIndex("email_1")`.
3. Ensure the partial index exists (Mongoose `syncIndexes()` on deploy, or create it explicitly if missing).

After cleanup, multiple guest users can be created without duplicate-key errors.

## Rollout Notes
- Deploy backend changes before frontend guest-session bootstrap.
- Run the **database migration** step above on any database that predates the partial email index (see [Database migration](#database-migration)).
- Frontend should request guest session before first checkout attempt when unauthenticated.
- Monitor:
  - guest checkout start vs completion
  - guest-to-user merge success rate
  - payment verify authorization failures
  - stale guest cleanup counts
