### PR TITLE
Implement Bespoke Form Submission

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -21,6 +21,7 @@ import paymentRoutes from "./routes/payment.routes.js";
 import productRoutes from "./routes/products.routes.js";
 import newsletterRoutes from "./routes/newsletter.routes.js";
 import contactRoutes from "./routes/contact.routes.js";
+import bespokeRoutes from "./routes/bespoke.routes.js";
 
 import { errorHandler } from "./middleware/index.js";
 
@@ -65,6 +66,7 @@ app.use(`${API_PREFIX}/payment`, paymentRoutes);
 app.use(`${API_PREFIX}/products`, routeLimiters.products, productRoutes);
 app.use(`${API_PREFIX}/newsletter`, routeLimiters.newsletter, newsletterRoutes);
 app.use(`${API_PREFIX}/contact`, routeLimiters.contact, contactRoutes);
+app.use(`${API_PREFIX}/bespoke`, routeLimiters.bespoke, bespokeRoutes);
 
 app.use(errorHandler);
 

--- a/src/config/cloudinary.js
+++ b/src/config/cloudinary.js
@@ -19,6 +19,30 @@ export const productUploads = multer({
   }),
 });
 
+const BESPOKE_REFERENCE_MAX_SIZE = 10 * 1024 * 1024; // 10 MB per file
+const BESPOKE_REFERENCE_MAX_COUNT = 5;
+
+const bespokeReferenceFileFilter = (req, file, cb) => {
+  if (!file.mimetype || !file.mimetype.startsWith("image/")) {
+    cb(new Error("Only image files are allowed for reference photos"), false);
+    return;
+  }
+  cb(null, true);
+};
+
+export const bespokeReferenceUploads = multer({
+  storage: new CloudinaryStorage({
+    cloudinary,
+    params: {
+      folder: "misqabbi/bespoke",
+    },
+  }),
+  limits: {
+    fileSize: BESPOKE_REFERENCE_MAX_SIZE,
+  },
+  fileFilter: bespokeReferenceFileFilter,
+}).array("referencePhotos", BESPOKE_REFERENCE_MAX_COUNT);
+
 export async function deleteAssets(publicIds = []) {
   if (!Array.isArray(publicIds) || publicIds.length === 0) return;
   try {

--- a/src/config/rateLimiter.js
+++ b/src/config/rateLimiter.js
@@ -67,6 +67,7 @@ export const routeLimiters = {
   order: rateLimiters.strict, // 10 requests
   payment: rateLimiters.strict, // 10 requests
   contact: rateLimiters.strict, // 10 requests
+  bespoke: rateLimiters.strict, // 10 requests
   admin: rateLimiters.lenient, // 200 requests
   products: rateLimiters.productSlowDown,
 };

--- a/src/constants/emailTemplates.js
+++ b/src/constants/emailTemplates.js
@@ -169,3 +169,54 @@ We're here for you every step of the way. If you have any questions or need assi
 With love and support,
 Your Girlies at Misqabbi 💕`;
 };
+
+/**
+ * Admin email for a new bespoke form submission (no persistence).
+ * @param {Object} payload - { fullName, email, phone, garmentType, garmentTypeOther, measurements, styleNotes, description, referencePhotoUrls }
+ */
+export const BESPOKE_EMAIL = payload => {
+  const {
+    fullName = "",
+    email = "",
+    phone = "",
+    garmentType = "",
+    garmentTypeOther = "",
+    measurements = "",
+    styleNotes = "",
+    description = "",
+    referencePhotoUrls = [],
+  } = payload;
+
+  const garmentLine =
+    garmentType === "other" && garmentTypeOther
+      ? `Garment type: Other (${garmentTypeOther})`
+      : garmentType
+        ? `Garment type: ${garmentType}`
+        : "";
+
+  const measurementsLine = measurements ? `Measurements:\n${measurements}` : "";
+  const styleNotesLine = styleNotes ? `Style notes:\n${styleNotes}` : "";
+  const photoLines =
+    referencePhotoUrls.length > 0
+      ? referencePhotoUrls
+          .map((url, i) => `Reference photo ${i + 1}: ${url}`)
+          .join("\n")
+      : "";
+
+  return `New Bespoke Submission
+
+You have received a new bespoke form submission:
+
+From: ${fullName}
+Email: ${email}
+${phone ? `Phone: ${phone}` : ""}
+${garmentLine ? `${garmentLine}\n` : ""}
+Description:
+${description}
+${measurementsLine ? `\n${measurementsLine}` : ""}
+${styleNotesLine ? `\n${styleNotesLine}` : ""}
+${photoLines ? `\nReference photos:\n${photoLines}` : ""}
+
+---
+This was sent via the Misqabbi bespoke form.`;
+};

--- a/src/controllers/bespoke.controller.js
+++ b/src/controllers/bespoke.controller.js
@@ -1,0 +1,78 @@
+import env from "../config/env.js";
+import logger from "../config/logger.js";
+import { formatResponse } from "../utils/responseFormatter.js";
+import { sendEmail } from "../services/emailService.js";
+import { BESPOKE_EMAIL } from "../constants/emailTemplates.js";
+
+/**
+ * @route   POST /bespoke
+ * @desc    Submit a bespoke form and send email to EMAIL_USER (same as contact). No persistence.
+ * @access  Public (guests and logged-in users)
+ *
+ * Workflow:
+ * - Multipart form parsed by multer; reference photos uploaded to Cloudinary; URLs attached to body
+ * - Validates form data via validateBespoke middleware
+ * - Builds email from BESPOKE_EMAIL template and sends to env.EMAIL_USER
+ * - Returns 201 with success message or 4xx/5xx with message for frontend toast
+ */
+export async function submitBespoke(req, res) {
+  const {
+    fullName,
+    email,
+    phone,
+    garmentType,
+    garmentTypeOther,
+    measurements,
+    styleNotes,
+    description,
+    referencePhotoUrls = [],
+  } = req.body;
+
+  try {
+    logger.info(`[submitBespoke] Bespoke form submission from: ${email}`);
+
+    const subject = `New bespoke from ${fullName}`;
+    const payload = {
+      fullName,
+      email,
+      phone: phone || "",
+      garmentType: garmentType || "",
+      garmentTypeOther: garmentTypeOther || "",
+      measurements: measurements || "",
+      styleNotes: styleNotes || "",
+      description,
+      referencePhotoUrls,
+    };
+    const emailContent = BESPOKE_EMAIL(payload);
+
+    const result = await sendEmail(env.EMAIL_USER, subject, emailContent);
+
+    if (result.success !== false) {
+      logger.info(
+        `[submitBespoke] Successfully sent bespoke email from: ${email}`
+      );
+      return res.status(201).json(
+        formatResponse({
+          message: "Bespoke form submitted successfully",
+        })
+      );
+    }
+
+    logger.error(`[submitBespoke] Failed to send bespoke email from: ${email}`);
+    return res.status(500).json(
+      formatResponse({
+        success: false,
+        message: "Failed to submit bespoke form",
+        error: result.error,
+      })
+    );
+  } catch (error) {
+    logger.error(`[submitBespoke] Unexpected error: ${error.message}`);
+    return res.status(500).json(
+      formatResponse({
+        success: false,
+        message: "Failed to submit bespoke form",
+      })
+    );
+  }
+}

--- a/src/middleware/upload.middleware.js
+++ b/src/middleware/upload.middleware.js
@@ -71,3 +71,23 @@ export const attachProductImagesToBody = (req, res, next) => {
  * Alias for attachProductImagesToBody for backward compatibility
  */
 export const attachVariantImagesToBody = attachProductImagesToBody;
+
+/**
+ * After bespoke reference photo uploads (multer with referencePhotos field), map
+ * req.files to req.body.referencePhotoUrls (array of Cloudinary URLs) for validator and email template.
+ */
+export const attachBespokeReferencePhotoUrlsToBody = (req, res, next) => {
+  const files = Array.isArray(req.files) ? req.files : [];
+  if (files.length > 0) {
+    req.body.referencePhotoUrls = files.map(file => {
+      const publicId = file.filename;
+      return getOptimisedUrl(publicId);
+    });
+  } else {
+    req.body.referencePhotoUrls = [];
+  }
+  logger.info(
+    `[upload.middleware] Attached ${req.body.referencePhotoUrls?.length ?? 0} reference photo URL(s) to body`
+  );
+  next();
+};

--- a/src/middleware/validator.middleware.js
+++ b/src/middleware/validator.middleware.js
@@ -4,6 +4,8 @@ import { variantProductValidator } from "../validators/variant.validator.js";
 import { orderValidator } from "../validators/order.validator.js";
 import { newsletterValidator } from "../validators/newsletter.validator.js";
 import { contactValidator } from "../validators/contact.validator.js";
+import { bespokeValidator } from "../validators/bespoke.validator.js";
+import { formatResponse } from "../utils/responseFormatter.js";
 
 export function validateUser(req, res, next) {
   const { error } = userValidator.validate(req.body, { abortEarly: false });
@@ -80,6 +82,18 @@ export function validateContact(req, res, next) {
     return res.status(400).json({
       errors: error.details.map(err => err.message),
     });
+  }
+  next();
+}
+
+export function validateBespoke(req, res, next) {
+  const { error } = bespokeValidator.validate(req.body, {
+    abortEarly: false,
+    allowUnknown: true,
+  });
+  if (error) {
+    const message = error.details[0]?.message ?? "Validation failed";
+    return res.status(400).json(formatResponse({ success: false, message }));
   }
   next();
 }

--- a/src/routes/bespoke.routes.js
+++ b/src/routes/bespoke.routes.js
@@ -1,0 +1,114 @@
+import express from "express";
+import { bespokeReferenceUploads } from "../config/cloudinary.js";
+import { attachBespokeReferencePhotoUrlsToBody } from "../middleware/upload.middleware.js";
+import { validateBespoke } from "../middleware/validator.middleware.js";
+import { submitBespoke } from "../controllers/bespoke.controller.js";
+import { formatResponse } from "../utils/responseFormatter.js";
+
+const router = express.Router();
+
+/**
+ * Handle multer errors (e.g. file size, file count, file type) with 400 and clear message for frontend toast.
+ */
+function handleBespokeUploadError(err, req, res, next) {
+  if (err) {
+    const message =
+      err.code === "LIMIT_FILE_SIZE"
+        ? "One or more files exceed the 10 MB limit"
+        : err.code === "LIMIT_FILE_COUNT"
+          ? "Maximum 5 reference photos allowed"
+          : err.code === "LIMIT_UNEXPECTED_FILE"
+            ? "Unexpected file field"
+            : err.message || "Invalid file upload";
+    return res.status(400).json(formatResponse({ success: false, message }));
+  }
+  next();
+}
+
+/**
+ * @swagger
+ * /bespoke:
+ *   post:
+ *     summary: Submit a bespoke form
+ *     description: Submit a bespoke form (multipart/form-data) with fullName, email, description, optional garmentType, measurements, styleNotes, referencePhotos. Sends email to admin; no persistence.
+ *     tags:
+ *       - Bespoke
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         multipart/form-data:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - fullName
+ *               - email
+ *               - description
+ *             properties:
+ *               fullName:
+ *                 type: string
+ *               email:
+ *                 type: string
+ *                 format: email
+ *               phone:
+ *                 type: string
+ *               garmentType:
+ *                 type: string
+ *                 enum: [pants, skirts, dresses, dungarees, other]
+ *               garmentTypeOther:
+ *                 type: string
+ *               measurements:
+ *                 type: string
+ *               styleNotes:
+ *                 type: string
+ *               description:
+ *                 type: string
+ *                 minLength: 10
+ *               referencePhotos:
+ *                 type: array
+ *                 items:
+ *                   type: string
+ *                   format: binary
+ *                 maxItems: 5
+ *     responses:
+ *       201:
+ *         description: Bespoke form submitted successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   example: true
+ *                 message:
+ *                   type: string
+ *                   example: "Bespoke form submitted successfully"
+ *       400:
+ *         description: Validation or upload error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   example: false
+ *                 message:
+ *                   type: string
+ *       500:
+ *         description: Server error
+ */
+router.post(
+  "/",
+  (req, res, next) => {
+    bespokeReferenceUploads(req, res, err => {
+      if (err) return handleBespokeUploadError(err, req, res, next);
+      next();
+    });
+  },
+  attachBespokeReferencePhotoUrlsToBody,
+  validateBespoke,
+  submitBespoke
+);
+
+export default router;

--- a/src/validators/bespoke.validator.js
+++ b/src/validators/bespoke.validator.js
@@ -1,0 +1,45 @@
+import Joi from "joi";
+import { EMAIL_REGEX } from "../utils/validators.js";
+
+const GARMENT_TYPES = ["pants", "skirts", "dresses", "dungarees", "other"];
+
+function measurementsJsonValidator(value, helpers) {
+  if (value === undefined || value === null || value === "") return value;
+  try {
+    JSON.parse(value);
+    return value;
+  } catch {
+    return helpers.error("any.invalid");
+  }
+}
+
+/**
+ * Joi validation schema for bespoke form submission (multipart/form-data).
+ * Fields: fullName, email, phone, garmentType, garmentTypeOther, measurements, styleNotes, description.
+ * referencePhotoUrls is set by upload middleware after Cloudinary upload.
+ */
+export const bespokeValidator = Joi.object({
+  fullName: Joi.string().trim().required().max(255),
+  email: Joi.string().trim().lowercase().pattern(EMAIL_REGEX).required(),
+  phone: Joi.string().trim().allow("").max(50),
+  garmentType: Joi.string()
+    .trim()
+    .valid(...GARMENT_TYPES, "")
+    .allow(""),
+  garmentTypeOther: Joi.string().trim().allow("").max(100),
+  measurements: Joi.string()
+    .trim()
+    .allow("")
+    .max(2000)
+    .when("garmentType", {
+      is: Joi.valid("pants", "skirts", "dresses", "dungarees"),
+      then: Joi.custom(measurementsJsonValidator).messages({
+        "any.invalid":
+          "measurements must be valid JSON when garment type is a known category",
+      }),
+      otherwise: Joi.string().trim().allow("").max(2000),
+    }),
+  styleNotes: Joi.string().trim().allow("").max(2000),
+  description: Joi.string().trim().required().min(10).max(5000),
+  referencePhotoUrls: Joi.array().items(Joi.string().uri()).max(5).optional(),
+});


### PR DESCRIPTION
This PR adds a public API for submitting bespoke (custom) garment requests. Submissions are sent as a formatted email to the same admin recipient used for the contact form. No persistence or database storage is introduced; the flow is form submission to email only.

## Key changes

### New endpoint

- **Method and path:** `POST /api/v1/bespoke`
- **Request format:** `multipart/form-data` (supports scalar fields and optional reference photo uploads)
- **Authentication:** None required. Both guests and logged-in users may submit. Cookies are supported for session context.
- **Rate limiting:** 10 requests per 15 minutes per IP (aligned with the contact form).

### Request handling

- **Cloudinary upload:** Reference photos are uploaded to Cloudinary in the `misqabbi/bespoke` folder. Limits: up to 5 images per submission, 10 MB per file, image types only.
- **Validation:** A dedicated Joi schema validates `fullName`, `email`, `description` (min length 10), optional `phone`, `garmentType` (pants, skirts, dresses, dungarees, other), optional `garmentTypeOther`, `measurements` (JSON string for known garment types, plain string when "other"), and `styleNotes`. Upload errors (size, count, type) return 400 with a clear message for the frontend.
- **Email:** The submission is formatted using a new `BESPOKE_EMAIL` template and sent to `env.EMAIL_USER` via the existing Resend-based email service. Reference photos appear in the email body as Cloudinary URLs only (no email attachments).