### PR TITLE
Add event model and admin CRUD with draft/publish/cancel lifecycle

### DIFF
--- a/src/config/cloudinary.js
+++ b/src/config/cloudinary.js
@@ -19,6 +19,15 @@ export const productUploads = multer({
   }),
 });
 
+export const eventBannerUploads = multer({
+  storage: new CloudinaryStorage({
+    cloudinary,
+    params: {
+      folder: "misqabbi/events",
+    },
+  }),
+});
+
 const BESPOKE_REFERENCE_MAX_SIZE = 10 * 1024 * 1024; // 10 MB per file
 const BESPOKE_REFERENCE_MAX_COUNT = 5;
 

--- a/src/controllers/events.admin.controller.js
+++ b/src/controllers/events.admin.controller.js
@@ -1,0 +1,191 @@
+import {
+  countEvents,
+  createEvent,
+  getEventById,
+  getPaginatedEvents,
+  updateEvent,
+  updateEventStatus,
+} from "../models/event.model.js";
+import { deleteAssets } from "../config/cloudinary.js";
+import logger from "../config/logger.js";
+import { assertEventStatusTransition } from "../services/eventStatusService.js";
+import { formatResponse } from "../utils/responseFormatter.js";
+
+export async function createEventAdmin(req, res) {
+  try {
+    const event = await createEvent(req.body, req.user._id);
+
+    res.status(201).json(
+      formatResponse({
+        message: "Event created successfully",
+        data: event,
+      })
+    );
+  } catch (error) {
+    logger.error(
+      `[events.admin.controller] Error creating event: ${error.message}`
+    );
+    res.status(400).json(
+      formatResponse({
+        success: false,
+        message: "Event creation failed",
+        error: "Invalid event data",
+      })
+    );
+  }
+}
+
+export async function getEventsAdmin(req, res) {
+  try {
+    const { page, limit, status, type, q } = req.query;
+    const pageNum = Math.max(parseInt(page) || 1, 1);
+    const limitNum = Math.max(parseInt(limit) || 10, 1);
+    const filters = {
+      status: status?.trim() || undefined,
+      type: type?.trim() || undefined,
+      q: q?.trim() || undefined,
+    };
+
+    const total = await countEvents(filters);
+
+    if (pageNum > Math.ceil(total / limitNum) && total > 0) {
+      return res.status(400).json(
+        formatResponse({
+          success: false,
+          error: "Requested page exceeds available event pages",
+        })
+      );
+    }
+
+    const events = await getPaginatedEvents(pageNum, limitNum, filters);
+
+    res.status(200).json(
+      formatResponse({
+        data: events,
+        total,
+        totalPages: Math.ceil(total / limitNum),
+        currentPage: pageNum,
+      })
+    );
+  } catch (error) {
+    logger.error(
+      `[events.admin.controller] Error listing events: ${error.message}`
+    );
+    res.status(500).json(
+      formatResponse({
+        success: false,
+        error: "Failed to load events",
+      })
+    );
+  }
+}
+
+export async function getEventByIdAdmin(req, res) {
+  try {
+    const event = await getEventById(req.params.id);
+
+    if (!event) {
+      return res.status(404).json(
+        formatResponse({
+          success: false,
+          error: "Event not found",
+        })
+      );
+    }
+
+    res.status(200).json(formatResponse({ data: event }));
+  } catch (error) {
+    logger.error(
+      `[events.admin.controller] Error loading event ${req.params.id}: ${error.message}`
+    );
+    res.status(500).json(
+      formatResponse({
+        success: false,
+        error: "Failed to load event",
+      })
+    );
+  }
+}
+
+export async function updateEventAdmin(req, res) {
+  try {
+    const existing = await getEventById(req.params.id);
+
+    if (!existing) {
+      return res.status(404).json(
+        formatResponse({
+          success: false,
+          error: "Event not found",
+        })
+      );
+    }
+
+    const payload = { ...req.body };
+
+    if (payload.banner && existing.banner?.publicId) {
+      try {
+        await deleteAssets([existing.banner.publicId]);
+      } catch (error) {
+        logger.warn(
+          `[events.admin.controller] Failed to delete replaced event banner ${existing._id}: ${error.message}`
+        );
+      }
+    }
+
+    const event = await updateEvent(req.params.id, payload);
+
+    res.status(200).json(
+      formatResponse({
+        message: "Event updated successfully",
+        data: event,
+      })
+    );
+  } catch (error) {
+    logger.error(
+      `[events.admin.controller] Error updating event ${req.params.id}: ${error.message}`
+    );
+    res.status(400).json(
+      formatResponse({
+        success: false,
+        message: "Event update failed",
+        error: "Invalid event data",
+      })
+    );
+  }
+}
+
+export async function updateEventStatusAdmin(req, res) {
+  try {
+    const existing = await getEventById(req.params.id);
+
+    if (!existing) {
+      return res.status(404).json(
+        formatResponse({
+          success: false,
+          error: "Event not found",
+        })
+      );
+    }
+
+    assertEventStatusTransition(existing.status, req.body.status);
+
+    const event = await updateEventStatus(req.params.id, req.body.status);
+
+    res.status(200).json(
+      formatResponse({
+        message: "Event status updated successfully",
+        data: event,
+      })
+    );
+  } catch (error) {
+    logger.error(
+      `[events.admin.controller] Error updating event status ${req.params.id}: ${error.message}`
+    );
+    res.status(400).json(
+      formatResponse({
+        success: false,
+        error: error.message,
+      })
+    );
+  }
+}

--- a/src/middleware/upload.middleware.js
+++ b/src/middleware/upload.middleware.js
@@ -72,6 +72,23 @@ export const attachProductImagesToBody = (req, res, next) => {
  */
 export const attachVariantImagesToBody = attachProductImagesToBody;
 
+export const attachEventBannerToBody = (req, res, next) => {
+  const bannerFile = req.files?.banner?.[0] || req.file;
+
+  if (bannerFile) {
+    const publicId = bannerFile.filename;
+    req.body.banner = {
+      url: getOptimisedUrl(publicId),
+      publicId,
+    };
+  }
+
+  logger.info(
+    `[upload.middleware] Attached event banner: ${req.body.banner ? "yes" : "no"}`
+  );
+  next();
+};
+
 /**
  * After bespoke reference photo uploads (multer with referencePhotos field), map
  * req.files to req.body.referencePhotoUrls (array of Cloudinary URLs) for validator and email template.

--- a/src/middleware/validator.middleware.js
+++ b/src/middleware/validator.middleware.js
@@ -5,6 +5,10 @@ import { orderValidator } from "../validators/order.validator.js";
 import { newsletterValidator } from "../validators/newsletter.validator.js";
 import { contactValidator } from "../validators/contact.validator.js";
 import { bespokeValidator } from "../validators/bespoke.validator.js";
+import {
+  eventStatusValidator,
+  eventValidator,
+} from "../validators/event.validator.js";
 import { formatResponse } from "../utils/responseFormatter.js";
 
 export function validateUser(req, res, next) {
@@ -95,5 +99,48 @@ export function validateBespoke(req, res, next) {
     const message = error.details[0]?.message ?? "Validation failed";
     return res.status(400).json(formatResponse({ success: false, message }));
   }
+  next();
+}
+
+export function validateEvent(req, res, next) {
+  const isUpdate = req.method === "PATCH" || req.method === "PUT";
+  const schema = isUpdate
+    ? eventValidator.fork(
+        ["name", "description", "eventDate", "type", "maxAttendees"],
+        fieldSchema => fieldSchema.optional()
+      )
+    : eventValidator;
+
+  const { error } = schema.validate(req.body, {
+    abortEarly: false,
+    allowUnknown: true,
+  });
+
+  if (error) {
+    return res.status(400).json(
+      formatResponse({
+        success: false,
+        errors: error.details.map(err => err.message),
+      })
+    );
+  }
+
+  next();
+}
+
+export function validateEventStatus(req, res, next) {
+  const { error } = eventStatusValidator.validate(req.body, {
+    abortEarly: false,
+  });
+
+  if (error) {
+    return res.status(400).json(
+      formatResponse({
+        success: false,
+        errors: error.details.map(err => err.message),
+      })
+    );
+  }
+
   next();
 }

--- a/src/models/event.model.js
+++ b/src/models/event.model.js
@@ -1,0 +1,121 @@
+import { Types } from "mongoose";
+import Event from "./event.mongo.js";
+import logger from "../config/logger.js";
+
+export async function createEvent(eventData, adminId) {
+  try {
+    return await Event.create({
+      ...eventData,
+      status: "draft",
+      createdBy: adminId,
+    });
+  } catch (error) {
+    logger.error(`[event.model] Error creating event: ${error.message}`);
+    throw error;
+  }
+}
+
+export async function getEventById(id) {
+  try {
+    if (!Types.ObjectId.isValid(id)) {
+      logger.warn(`[event.model] Invalid event ID: ${id}`);
+      return null;
+    }
+
+    return await Event.findById(id);
+  } catch (error) {
+    logger.error(`[event.model] Error finding event ${id}: ${error.message}`);
+    throw error;
+  }
+}
+
+export async function getPaginatedEvents(page = 1, limit = 10, params = {}) {
+  try {
+    const filter = {};
+    const sort = { eventDate: 1, createdAt: -1 };
+    const skip = (page - 1) * limit;
+
+    if (params.status) {
+      filter.status = params.status;
+    }
+
+    if (params.type) {
+      filter.type = params.type;
+    }
+
+    if (params.q && typeof params.q === "string") {
+      filter.$text = { $search: params.q };
+      sort.score = { $meta: "textScore" };
+    }
+
+    return await Event.find(filter)
+      .sort(sort)
+      .skip(skip)
+      .limit(limit)
+      .populate({ path: "createdBy", select: "displayName email" });
+  } catch (error) {
+    logger.error(`[event.model] Error listing events: ${error.message}`);
+    throw error;
+  }
+}
+
+export async function countEvents(params = {}) {
+  try {
+    const filter = {};
+
+    if (params.status) {
+      filter.status = params.status;
+    }
+
+    if (params.type) {
+      filter.type = params.type;
+    }
+
+    if (params.q && typeof params.q === "string") {
+      filter.$text = { $search: params.q };
+    }
+
+    return await Event.countDocuments(filter);
+  } catch (error) {
+    logger.error(`[event.model] Error counting events: ${error.message}`);
+    throw error;
+  }
+}
+
+export async function updateEvent(id, updates) {
+  try {
+    if (!Types.ObjectId.isValid(id)) {
+      return null;
+    }
+
+    delete updates.createdBy;
+    delete updates.status;
+
+    return await Event.findByIdAndUpdate(id, updates, {
+      new: true,
+      runValidators: true,
+    });
+  } catch (error) {
+    logger.error(`[event.model] Error updating event ${id}: ${error.message}`);
+    throw error;
+  }
+}
+
+export async function updateEventStatus(id, status) {
+  try {
+    if (!Types.ObjectId.isValid(id)) {
+      return null;
+    }
+
+    return await Event.findByIdAndUpdate(
+      id,
+      { status },
+      { new: true, runValidators: true }
+    );
+  } catch (error) {
+    logger.error(
+      `[event.model] Error updating event ${id} status: ${error.message}`
+    );
+    throw error;
+  }
+}

--- a/src/models/event.mongo.js
+++ b/src/models/event.mongo.js
@@ -1,0 +1,104 @@
+import { Schema, model } from "mongoose";
+
+export const EVENT_TYPES = ["free", "paid"];
+export const EVENT_STATUSES = ["draft", "published", "cancelled"];
+
+const eventAssetSchema = new Schema(
+  {
+    url: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+    publicId: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+  },
+  { _id: false }
+);
+
+const eventVenueSchema = new Schema(
+  {
+    name: {
+      type: String,
+      trim: true,
+      default: "",
+    },
+    address: {
+      type: String,
+      trim: true,
+      default: "",
+    },
+    url: {
+      type: String,
+      trim: true,
+      default: "",
+    },
+  },
+  { _id: false }
+);
+
+const eventSchema = new Schema(
+  {
+    name: {
+      type: String,
+      required: true,
+      trim: true,
+      index: true,
+    },
+    description: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+    eventDate: {
+      type: Date,
+      required: true,
+      index: true,
+    },
+    type: {
+      type: String,
+      enum: EVENT_TYPES,
+      required: true,
+      index: true,
+    },
+    status: {
+      type: String,
+      enum: EVENT_STATUSES,
+      default: "draft",
+      index: true,
+    },
+    maxAttendees: {
+      type: Number,
+      required: true,
+      min: 1,
+    },
+    venue: {
+      type: eventVenueSchema,
+      default: undefined,
+    },
+    banner: {
+      type: eventAssetSchema,
+      default: undefined,
+    },
+    createdBy: {
+      type: Schema.Types.ObjectId,
+      ref: "User",
+      required: true,
+      index: true,
+    },
+  },
+  { timestamps: true }
+);
+
+eventSchema.index({ status: 1, type: 1, eventDate: 1 });
+eventSchema.index(
+  { name: "text", description: "text" },
+  { name: "EventTextIndex" }
+);
+
+const Event = model("Event", eventSchema);
+
+export default Event;

--- a/src/routes/admin.routes.js
+++ b/src/routes/admin.routes.js
@@ -2,14 +2,17 @@ import express from "express";
 
 import { authenticateToken, checkAdmin } from "../middleware/index.js";
 import {
+  validateEvent,
+  validateEventStatus,
   validateProduct,
   validateVariantProduct,
 } from "../middleware/validator.middleware.js";
 import {
+  attachEventBannerToBody,
   attachVariantImagesToBody,
   attachProductImagesToBody,
 } from "../middleware/upload.middleware.js";
-import { productUploads } from "../config/cloudinary.js";
+import { eventBannerUploads, productUploads } from "../config/cloudinary.js";
 
 import {
   getUserAnalyticsHandler,
@@ -25,6 +28,13 @@ import {
   getDiscountUsageAdmin,
   getDiscountStatsAdmin,
 } from "../controllers/discount.controller.js";
+import {
+  createEventAdmin,
+  getEventByIdAdmin,
+  getEventsAdmin,
+  updateEventAdmin,
+  updateEventStatusAdmin,
+} from "../controllers/events.admin.controller.js";
 import {
   getAllOrdersAdmin,
   updateOrderStatusAdmin,
@@ -126,6 +136,38 @@ router.get(
   authenticateToken,
   checkAdmin,
   getAdminDashboardHandler
+);
+
+router.post(
+  "/events",
+  authenticateToken,
+  checkAdmin,
+  eventBannerUploads.fields([{ name: "banner", maxCount: 1 }]),
+  attachEventBannerToBody,
+  validateEvent,
+  createEventAdmin
+);
+
+router.get("/events", authenticateToken, checkAdmin, getEventsAdmin);
+
+router.get("/events/:id", authenticateToken, checkAdmin, getEventByIdAdmin);
+
+router.patch(
+  "/events/:id",
+  authenticateToken,
+  checkAdmin,
+  eventBannerUploads.fields([{ name: "banner", maxCount: 1 }]),
+  attachEventBannerToBody,
+  validateEvent,
+  updateEventAdmin
+);
+
+router.patch(
+  "/events/:id/status",
+  authenticateToken,
+  checkAdmin,
+  validateEventStatus,
+  updateEventStatusAdmin
 );
 
 /**

--- a/src/services/eventStatusService.js
+++ b/src/services/eventStatusService.js
@@ -1,0 +1,28 @@
+export const EVENT_STATUSES = ["draft", "published", "cancelled"];
+export const EVENT_STATUS_TRANSITIONS = {
+  draft: ["published", "cancelled"],
+  published: ["cancelled"],
+  cancelled: [],
+};
+
+export function canTransitionEventStatus(currentStatus, nextStatus) {
+  return EVENT_STATUS_TRANSITIONS[currentStatus]?.includes(nextStatus) ?? false;
+}
+
+export function assertEventStatusTransition(currentStatus, nextStatus) {
+  if (!EVENT_STATUSES.includes(nextStatus)) {
+    throw new Error("Invalid event status");
+  }
+
+  if (currentStatus === nextStatus) {
+    return true;
+  }
+
+  if (!canTransitionEventStatus(currentStatus, nextStatus)) {
+    throw new Error(
+      `Cannot transition event from ${currentStatus} to ${nextStatus}`
+    );
+  }
+
+  return true;
+}

--- a/src/validators/event.validator.js
+++ b/src/validators/event.validator.js
@@ -1,0 +1,45 @@
+import Joi from "joi";
+import { EVENT_TYPES, EVENT_STATUSES } from "../models/event.mongo.js";
+
+const venueValidator = Joi.object({
+  name: Joi.string().trim().allow("").optional(),
+  address: Joi.string().trim().allow("").optional(),
+  url: Joi.string().trim().uri().allow("").optional(),
+}).optional();
+
+const bannerValidator = Joi.object({
+  url: Joi.string().uri().required(),
+  publicId: Joi.string().trim().required(),
+})
+  .allow(null)
+  .optional();
+
+export const eventValidator = Joi.object({
+  name: Joi.string().trim().min(1).required().messages({
+    "string.empty": "Event name is required",
+    "any.required": "Event name is required",
+  }),
+  description: Joi.string().trim().min(1).required().messages({
+    "string.empty": "Event description is required",
+    "any.required": "Event description is required",
+  }),
+  eventDate: Joi.date().iso().required().messages({
+    "date.base": "Event date must be a valid date",
+    "any.required": "Event date is required",
+  }),
+  type: Joi.string()
+    .valid(...EVENT_TYPES)
+    .required(),
+  maxAttendees: Joi.number().integer().min(1).required().messages({
+    "number.min": "Event size must be at least 1",
+    "any.required": "Event size is required",
+  }),
+  venue: venueValidator,
+  banner: bannerValidator,
+});
+
+export const eventStatusValidator = Joi.object({
+  status: Joi.string()
+    .valid(...EVENT_STATUSES)
+    .required(),
+});

--- a/tests/public/events/eventStatusService.test.js
+++ b/tests/public/events/eventStatusService.test.js
@@ -1,0 +1,33 @@
+/*eslint-disable no-undef */
+import {
+  assertEventStatusTransition,
+  canTransitionEventStatus,
+} from "../../../src/services/eventStatusService.js";
+
+describe("eventStatusService", () => {
+  it("allows draft events to be published or cancelled", () => {
+    expect(canTransitionEventStatus("draft", "published")).toBe(true);
+    expect(canTransitionEventStatus("draft", "cancelled")).toBe(true);
+  });
+
+  it("allows published events to be cancelled", () => {
+    expect(canTransitionEventStatus("published", "cancelled")).toBe(true);
+  });
+
+  it("prevents cancelled events from being restored", () => {
+    expect(canTransitionEventStatus("cancelled", "draft")).toBe(false);
+    expect(canTransitionEventStatus("cancelled", "published")).toBe(false);
+  });
+
+  it("throws for invalid lifecycle transitions", () => {
+    expect(() =>
+      assertEventStatusTransition("published", "draft")
+    ).toThrow("Cannot transition event from published to draft");
+  });
+
+  it("throws for unsupported statuses", () => {
+    expect(() => assertEventStatusTransition("draft", "archived")).toThrow(
+      "Invalid event status"
+    );
+  });
+});

--- a/tests/public/events/eventValidator.test.js
+++ b/tests/public/events/eventValidator.test.js
@@ -1,0 +1,71 @@
+/*eslint-disable no-undef */
+import {
+  eventStatusValidator,
+  eventValidator,
+} from "../../../src/validators/event.validator.js";
+
+describe("eventValidator", () => {
+  const validEvent = {
+    name: "Summer Pop-up",
+    description: "A community event for Misqabbi customers.",
+    eventDate: "2026-08-01T18:00:00.000Z",
+    type: "free",
+    maxAttendees: 50,
+    venue: {
+      name: "Studio",
+      address: "Accra",
+      url: "https://example.com/venue",
+    },
+  };
+
+  it("accepts a valid event creation payload", () => {
+    const { error } = eventValidator.validate(validEvent, {
+      abortEarly: false,
+    });
+
+    expect(error).toBeUndefined();
+  });
+
+  it("requires core event fields on creation", () => {
+    const { error } = eventValidator.validate({}, { abortEarly: false });
+
+    expect(error.details.map(detail => detail.message)).toEqual(
+      expect.arrayContaining([
+        "Event name is required",
+        "Event description is required",
+        "Event date is required",
+        "\"type\" is required",
+        "Event size is required",
+      ])
+    );
+  });
+
+  it("rejects invalid event types", () => {
+    const { error } = eventValidator.validate(
+      { ...validEvent, type: "invite-only" },
+      { abortEarly: false }
+    );
+
+    expect(error.details[0].message).toContain("must be one of");
+  });
+
+  it("rejects event sizes below one attendee", () => {
+    const { error } = eventValidator.validate(
+      { ...validEvent, maxAttendees: 0 },
+      { abortEarly: false }
+    );
+
+    expect(error.details.map(detail => detail.message)).toContain(
+      "Event size must be at least 1"
+    );
+  });
+
+  it("validates status update payloads", () => {
+    expect(eventStatusValidator.validate({ status: "published" }).error).toBe(
+      undefined
+    );
+    expect(
+      eventStatusValidator.validate({ status: "archived" }).error
+    ).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Description
This branch adds the core event management foundation for the Misqabbi admin store. It introduces the `Event` model, admin CRUD endpoints, lifecycle status transitions, and optional banner upload support using the existing Cloudinary/multer patterns. This establishes the base event entity that future branches will extend with tickets, registration forms, volunteer applications, attendees, and checkout.

## Key changes
- Add `Event` Mongoose model with name, description, event date, type, status, max attendees, optional venue, optional banner, and creator metadata.
- Add event data-access helpers for create, list, count, get by ID, update, and status updates.
- Add `eventStatusService` to enforce allowed lifecycle transitions.
- Add admin routes for creating, listing, viewing, updating, publishing, and cancelling events.
- Add event banner upload support through `eventBannerUploads` and `attachEventBannerToBody`.
- Add Joi validators and middleware for event creation/update and status update payloads.
- Add unit tests for lifecycle transitions and event validation, including max attendee validation.
