### PR TITLE
Add configurable ticket types for paid events with expiry defaults

### DIFF
--- a/src/controllers/events.admin.controller.js
+++ b/src/controllers/events.admin.controller.js
@@ -1,14 +1,24 @@
 import {
+  addTicketTypeToEvent,
   countEvents,
   createEvent,
+  deleteEventTicketType,
   getEventById,
   getPaginatedEvents,
   updateEvent,
+  updateEventTicketType,
   updateEventStatus,
 } from "../models/event.model.js";
 import { deleteAssets } from "../config/cloudinary.js";
 import logger from "../config/logger.js";
 import { assertEventStatusTransition } from "../services/eventStatusService.js";
+import {
+  assertCanDeleteTicketType,
+  assertCanUpdateTicketType,
+  assertPaidEventCanPublish,
+  assertPaidEventSupportsTickets,
+  buildTicketTypePayload,
+} from "../services/eventTicketService.js";
 import { formatResponse } from "../utils/responseFormatter.js";
 
 export async function createEventAdmin(req, res) {
@@ -168,6 +178,9 @@ export async function updateEventStatusAdmin(req, res) {
     }
 
     assertEventStatusTransition(existing.status, req.body.status);
+    if (req.body.status === "published") {
+      assertPaidEventCanPublish(existing);
+    }
 
     const event = await updateEventStatus(req.params.id, req.body.status);
 
@@ -182,6 +195,107 @@ export async function updateEventStatusAdmin(req, res) {
       `[events.admin.controller] Error updating event status ${req.params.id}: ${error.message}`
     );
     res.status(400).json(
+      formatResponse({
+        success: false,
+        error: error.message,
+      })
+    );
+  }
+}
+
+export async function addEventTicketTypeAdmin(req, res) {
+  try {
+    const event = await getEventById(req.params.id);
+    assertPaidEventSupportsTickets(event);
+
+    const ticketTypePayload = buildTicketTypePayload(req.body, event);
+    const updatedEvent = await addTicketTypeToEvent(
+      req.params.id,
+      ticketTypePayload
+    );
+
+    res.status(201).json(
+      formatResponse({
+        message: "Ticket type added successfully",
+        data: updatedEvent,
+      })
+    );
+  } catch (error) {
+    logger.error(
+      `[events.admin.controller] Error adding ticket type to event ${req.params.id}: ${error.message}`
+    );
+    res.status(error.message === "Event not found" ? 404 : 400).json(
+      formatResponse({
+        success: false,
+        error: error.message,
+      })
+    );
+  }
+}
+
+export async function updateEventTicketTypeAdmin(req, res) {
+  try {
+    const event = await getEventById(req.params.id);
+    assertPaidEventSupportsTickets(event);
+
+    const ticketType = event.ticketTypes.id(req.params.ticketTypeId);
+    assertCanUpdateTicketType(ticketType, req.body);
+
+    const updates = { ...req.body };
+    if (updates.expiresAt) {
+      updates.expiresAt = new Date(updates.expiresAt);
+      updates.expirySource = "manual";
+    }
+
+    const result = await updateEventTicketType(
+      req.params.id,
+      req.params.ticketTypeId,
+      updates
+    );
+
+    res.status(200).json(
+      formatResponse({
+        message: "Ticket type updated successfully",
+        data: result.event,
+      })
+    );
+  } catch (error) {
+    logger.error(
+      `[events.admin.controller] Error updating ticket type ${req.params.ticketTypeId}: ${error.message}`
+    );
+    res.status(error.message === "Event not found" ? 404 : 400).json(
+      formatResponse({
+        success: false,
+        error: error.message,
+      })
+    );
+  }
+}
+
+export async function deleteEventTicketTypeAdmin(req, res) {
+  try {
+    const event = await getEventById(req.params.id);
+    assertPaidEventSupportsTickets(event);
+
+    const ticketType = event.ticketTypes.id(req.params.ticketTypeId);
+    assertCanDeleteTicketType(ticketType);
+
+    const result = await deleteEventTicketType(
+      req.params.id,
+      req.params.ticketTypeId
+    );
+
+    res.status(200).json(
+      formatResponse({
+        message: "Ticket type deleted successfully",
+        data: result.event,
+      })
+    );
+  } catch (error) {
+    logger.error(
+      `[events.admin.controller] Error deleting ticket type ${req.params.ticketTypeId}: ${error.message}`
+    );
+    res.status(error.message === "Event not found" ? 404 : 400).json(
       formatResponse({
         success: false,
         error: error.message,

--- a/src/middleware/validator.middleware.js
+++ b/src/middleware/validator.middleware.js
@@ -7,6 +7,7 @@ import { contactValidator } from "../validators/contact.validator.js";
 import { bespokeValidator } from "../validators/bespoke.validator.js";
 import {
   eventStatusValidator,
+  eventTicketTypeValidator,
   eventValidator,
 } from "../validators/event.validator.js";
 import { formatResponse } from "../utils/responseFormatter.js";
@@ -130,6 +131,31 @@ export function validateEvent(req, res, next) {
 
 export function validateEventStatus(req, res, next) {
   const { error } = eventStatusValidator.validate(req.body, {
+    abortEarly: false,
+  });
+
+  if (error) {
+    return res.status(400).json(
+      formatResponse({
+        success: false,
+        errors: error.details.map(err => err.message),
+      })
+    );
+  }
+
+  next();
+}
+
+export function validateEventTicketType(req, res, next) {
+  const isUpdate = req.method === "PATCH" || req.method === "PUT";
+  const schema = isUpdate
+    ? eventTicketTypeValidator.fork(
+        ["name", "pricePesewas", "maxQuantity"],
+        fieldSchema => fieldSchema.optional()
+      )
+    : eventTicketTypeValidator;
+
+  const { error } = schema.validate(req.body, {
     abortEarly: false,
   });
 

--- a/src/models/event.model.js
+++ b/src/models/event.model.js
@@ -4,8 +4,11 @@ import logger from "../config/logger.js";
 
 export async function createEvent(eventData, adminId) {
   try {
+    const payload = { ...eventData };
+    delete payload.ticketTypes;
+
     return await Event.create({
-      ...eventData,
+      ...payload,
       status: "draft",
       createdBy: adminId,
     });
@@ -90,6 +93,7 @@ export async function updateEvent(id, updates) {
 
     delete updates.createdBy;
     delete updates.status;
+    delete updates.ticketTypes;
 
     return await Event.findByIdAndUpdate(id, updates, {
       new: true,
@@ -115,6 +119,65 @@ export async function updateEventStatus(id, status) {
   } catch (error) {
     logger.error(
       `[event.model] Error updating event ${id} status: ${error.message}`
+    );
+    throw error;
+  }
+}
+
+export async function addTicketTypeToEvent(id, ticketTypeData) {
+  try {
+    const event = await getEventById(id);
+    if (!event) return null;
+
+    event.ticketTypes.push(ticketTypeData);
+    return await event.save();
+  } catch (error) {
+    logger.error(
+      `[event.model] Error adding ticket type to event ${id}: ${error.message}`
+    );
+    throw error;
+  }
+}
+
+export async function updateEventTicketType(id, ticketTypeId, updates) {
+  try {
+    const event = await getEventById(id);
+    if (!event) return null;
+
+    const ticketType = event.ticketTypes.id(ticketTypeId);
+    if (!ticketType) {
+      return { event, ticketType: null };
+    }
+
+    ticketType.set(updates);
+    await event.save();
+
+    return { event, ticketType };
+  } catch (error) {
+    logger.error(
+      `[event.model] Error updating ticket type ${ticketTypeId} on event ${id}: ${error.message}`
+    );
+    throw error;
+  }
+}
+
+export async function deleteEventTicketType(id, ticketTypeId) {
+  try {
+    const event = await getEventById(id);
+    if (!event) return null;
+
+    const ticketType = event.ticketTypes.id(ticketTypeId);
+    if (!ticketType) {
+      return { event, ticketType: null };
+    }
+
+    ticketType.deleteOne();
+    await event.save();
+
+    return { event, ticketType };
+  } catch (error) {
+    logger.error(
+      `[event.model] Error deleting ticket type ${ticketTypeId} from event ${id}: ${error.message}`
     );
     throw error;
   }

--- a/src/models/event.mongo.js
+++ b/src/models/event.mongo.js
@@ -40,6 +40,45 @@ const eventVenueSchema = new Schema(
   { _id: false }
 );
 
+const ticketTypeSchema = new Schema(
+  {
+    name: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+    pricePesewas: {
+      type: Number,
+      required: true,
+      min: 1,
+    },
+    maxQuantity: {
+      type: Number,
+      required: true,
+      min: 1,
+    },
+    soldCount: {
+      type: Number,
+      min: 0,
+      default: 0,
+    },
+    expiresAt: {
+      type: Date,
+      required: true,
+    },
+    expirySource: {
+      type: String,
+      enum: ["auto", "manual"],
+      default: "auto",
+    },
+    isActive: {
+      type: Boolean,
+      default: true,
+    },
+  },
+  { timestamps: true }
+);
+
 const eventSchema = new Schema(
   {
     name: {
@@ -82,6 +121,10 @@ const eventSchema = new Schema(
     banner: {
       type: eventAssetSchema,
       default: undefined,
+    },
+    ticketTypes: {
+      type: [ticketTypeSchema],
+      default: [],
     },
     createdBy: {
       type: Schema.Types.ObjectId,

--- a/src/routes/admin.routes.js
+++ b/src/routes/admin.routes.js
@@ -4,6 +4,7 @@ import { authenticateToken, checkAdmin } from "../middleware/index.js";
 import {
   validateEvent,
   validateEventStatus,
+  validateEventTicketType,
   validateProduct,
   validateVariantProduct,
 } from "../middleware/validator.middleware.js";
@@ -30,9 +31,12 @@ import {
 } from "../controllers/discount.controller.js";
 import {
   createEventAdmin,
+  addEventTicketTypeAdmin,
+  deleteEventTicketTypeAdmin,
   getEventByIdAdmin,
   getEventsAdmin,
   updateEventAdmin,
+  updateEventTicketTypeAdmin,
   updateEventStatusAdmin,
 } from "../controllers/events.admin.controller.js";
 import {
@@ -168,6 +172,29 @@ router.patch(
   checkAdmin,
   validateEventStatus,
   updateEventStatusAdmin
+);
+
+router.post(
+  "/events/:id/ticket-types",
+  authenticateToken,
+  checkAdmin,
+  validateEventTicketType,
+  addEventTicketTypeAdmin
+);
+
+router.patch(
+  "/events/:id/ticket-types/:ticketTypeId",
+  authenticateToken,
+  checkAdmin,
+  validateEventTicketType,
+  updateEventTicketTypeAdmin
+);
+
+router.delete(
+  "/events/:id/ticket-types/:ticketTypeId",
+  authenticateToken,
+  checkAdmin,
+  deleteEventTicketTypeAdmin
 );
 
 /**

--- a/src/services/eventTicketService.js
+++ b/src/services/eventTicketService.js
@@ -1,0 +1,96 @@
+const ONE_DAY_IN_MS = 24 * 60 * 60 * 1000;
+
+export function computeDefaultExpiry(eventDate) {
+  const parsedEventDate = new Date(eventDate);
+
+  if (Number.isNaN(parsedEventDate.getTime())) {
+    throw new Error("Invalid event date");
+  }
+
+  return new Date(parsedEventDate.getTime() + ONE_DAY_IN_MS);
+}
+
+export function canDeleteTicketType(ticketType) {
+  return Number(ticketType?.soldCount ?? 0) === 0;
+}
+
+export function assertPaidEventSupportsTickets(event) {
+  if (!event) {
+    throw new Error("Event not found");
+  }
+
+  if (event.type !== "paid") {
+    throw new Error("Ticket types can only be configured for paid events");
+  }
+}
+
+export function buildTicketTypePayload(ticketTypeData, event) {
+  const hasManualExpiry = Boolean(ticketTypeData.expiresAt);
+  const expiresAt = hasManualExpiry
+    ? new Date(ticketTypeData.expiresAt)
+    : computeDefaultExpiry(event.eventDate);
+
+  if (Number.isNaN(expiresAt.getTime())) {
+    throw new Error("Invalid ticket expiry date");
+  }
+
+  return {
+    name: ticketTypeData.name,
+    pricePesewas: ticketTypeData.pricePesewas,
+    maxQuantity: ticketTypeData.maxQuantity,
+    soldCount: 0,
+    expiresAt,
+    expirySource: hasManualExpiry ? "manual" : "auto",
+    isActive: ticketTypeData.isActive ?? true,
+  };
+}
+
+export function assertCanDeleteTicketType(ticketType) {
+  if (!ticketType) {
+    throw new Error("Ticket type not found");
+  }
+
+  if (!canDeleteTicketType(ticketType)) {
+    throw new Error("Ticket types with purchased tickets cannot be deleted");
+  }
+}
+
+export function assertCanUpdateTicketType(ticketType, updates) {
+  if (!ticketType) {
+    throw new Error("Ticket type not found");
+  }
+
+  if (
+    updates.maxQuantity !== undefined &&
+    Number(updates.maxQuantity) < Number(ticketType.soldCount ?? 0)
+  ) {
+    throw new Error("Ticket max quantity cannot be less than tickets sold");
+  }
+}
+
+export function hasActiveTicketType(event) {
+  return event?.ticketTypes?.some(ticketType => ticketType.isActive) ?? false;
+}
+
+export function assertPaidEventCanPublish(event) {
+  if (event?.type === "paid" && !hasActiveTicketType(event)) {
+    throw new Error("Paid events require at least one active ticket type");
+  }
+}
+
+export function isTicketPurchasable(
+  ticketType,
+  event,
+  quantity = 1,
+  now = new Date()
+) {
+  if (!ticketType || !event) return false;
+  if (event.type !== "paid" || event.status !== "published") return false;
+  if (!ticketType.isActive) return false;
+  if (new Date(ticketType.expiresAt) <= now) return false;
+
+  const remaining =
+    Number(ticketType.maxQuantity ?? 0) - Number(ticketType.soldCount ?? 0);
+
+  return remaining >= quantity;
+}

--- a/src/validators/event.validator.js
+++ b/src/validators/event.validator.js
@@ -43,3 +43,20 @@ export const eventStatusValidator = Joi.object({
     .valid(...EVENT_STATUSES)
     .required(),
 });
+
+export const eventTicketTypeValidator = Joi.object({
+  name: Joi.string().trim().min(1).required().messages({
+    "string.empty": "Ticket name is required",
+    "any.required": "Ticket name is required",
+  }),
+  pricePesewas: Joi.number().integer().min(1).required().messages({
+    "number.min": "Ticket price must be at least 1 pesewa",
+    "any.required": "Ticket price is required",
+  }),
+  maxQuantity: Joi.number().integer().min(1).required().messages({
+    "number.min": "Ticket max quantity must be at least 1",
+    "any.required": "Ticket max quantity is required",
+  }),
+  expiresAt: Joi.date().iso().optional(),
+  isActive: Joi.boolean().optional(),
+});

--- a/tests/public/events/eventTicketService.test.js
+++ b/tests/public/events/eventTicketService.test.js
@@ -1,0 +1,113 @@
+/*eslint-disable no-undef */
+import {
+  assertCanDeleteTicketType,
+  assertCanUpdateTicketType,
+  assertPaidEventCanPublish,
+  assertPaidEventSupportsTickets,
+  buildTicketTypePayload,
+  canDeleteTicketType,
+  computeDefaultExpiry,
+  isTicketPurchasable,
+} from "../../../src/services/eventTicketService.js";
+
+describe("eventTicketService", () => {
+  const eventDate = "2026-08-01T18:00:00.000Z";
+  const paidPublishedEvent = {
+    type: "paid",
+    status: "published",
+    eventDate,
+    ticketTypes: [],
+  };
+
+  it("computes the default ticket expiry one day after the event date", () => {
+    expect(computeDefaultExpiry(eventDate).toISOString()).toBe(
+      "2026-08-02T18:00:00.000Z"
+    );
+  });
+
+  it("builds ticket payloads with auto expiry when no expiry is provided", () => {
+    const payload = buildTicketTypePayload(
+      {
+        name: "Early Bird",
+        pricePesewas: 5000,
+        maxQuantity: 20,
+      },
+      paidPublishedEvent
+    );
+
+    expect(payload).toMatchObject({
+      name: "Early Bird",
+      pricePesewas: 5000,
+      maxQuantity: 20,
+      soldCount: 0,
+      expirySource: "auto",
+      isActive: true,
+    });
+    expect(payload.expiresAt.toISOString()).toBe("2026-08-02T18:00:00.000Z");
+  });
+
+  it("marks ticket expiry as manual when an override is provided", () => {
+    const payload = buildTicketTypePayload(
+      {
+        name: "VIP",
+        pricePesewas: 15000,
+        maxQuantity: 10,
+        expiresAt: "2026-07-15T18:00:00.000Z",
+      },
+      paidPublishedEvent
+    );
+
+    expect(payload.expirySource).toBe("manual");
+    expect(payload.expiresAt.toISOString()).toBe("2026-07-15T18:00:00.000Z");
+  });
+
+  it("only allows deleting ticket types without sold tickets", () => {
+    expect(canDeleteTicketType({ soldCount: 0 })).toBe(true);
+    expect(canDeleteTicketType({ soldCount: 1 })).toBe(false);
+    expect(() => assertCanDeleteTicketType({ soldCount: 1 })).toThrow(
+      "Ticket types with purchased tickets cannot be deleted"
+    );
+  });
+
+  it("prevents reducing max quantity below sold count", () => {
+    expect(() =>
+      assertCanUpdateTicketType({ soldCount: 5 }, { maxQuantity: 4 })
+    ).toThrow("Ticket max quantity cannot be less than tickets sold");
+  });
+
+  it("requires ticket types to belong to paid events", () => {
+    expect(() => assertPaidEventSupportsTickets({ type: "free" })).toThrow(
+      "Ticket types can only be configured for paid events"
+    );
+  });
+
+  it("requires active ticket types before publishing paid events", () => {
+    expect(() =>
+      assertPaidEventCanPublish({ type: "paid", ticketTypes: [] })
+    ).toThrow("Paid events require at least one active ticket type");
+
+    expect(() =>
+      assertPaidEventCanPublish({
+        type: "paid",
+        ticketTypes: [{ isActive: true }],
+      })
+    ).not.toThrow();
+  });
+
+  it("checks whether a ticket type is purchasable", () => {
+    const now = new Date("2026-07-01T12:00:00.000Z");
+    const ticketType = {
+      isActive: true,
+      expiresAt: "2026-08-02T18:00:00.000Z",
+      maxQuantity: 10,
+      soldCount: 8,
+    };
+
+    expect(isTicketPurchasable(ticketType, paidPublishedEvent, 2, now)).toBe(
+      true
+    );
+    expect(isTicketPurchasable(ticketType, paidPublishedEvent, 3, now)).toBe(
+      false
+    );
+  });
+});

--- a/tests/public/events/eventValidator.test.js
+++ b/tests/public/events/eventValidator.test.js
@@ -1,6 +1,7 @@
 /*eslint-disable no-undef */
 import {
   eventStatusValidator,
+  eventTicketTypeValidator,
   eventValidator,
 } from "../../../src/validators/event.validator.js";
 
@@ -67,5 +68,34 @@ describe("eventValidator", () => {
     expect(
       eventStatusValidator.validate({ status: "archived" }).error
     ).toBeDefined();
+  });
+
+  it("validates ticket type creation payloads", () => {
+    const { error } = eventTicketTypeValidator.validate({
+      name: "Early Bird",
+      pricePesewas: 5000,
+      maxQuantity: 20,
+      expiresAt: "2026-08-02T18:00:00.000Z",
+    });
+
+    expect(error).toBeUndefined();
+  });
+
+  it("rejects invalid ticket type prices and quantities", () => {
+    const { error } = eventTicketTypeValidator.validate(
+      {
+        name: "Early Bird",
+        pricePesewas: 0,
+        maxQuantity: 0,
+      },
+      { abortEarly: false }
+    );
+
+    expect(error.details.map(detail => detail.message)).toEqual(
+      expect.arrayContaining([
+        "Ticket price must be at least 1 pesewa",
+        "Ticket max quantity must be at least 1",
+      ])
+    );
   });
 });


### PR DESCRIPTION
## Description
This branch adds configurable ticket types to paid events using embedded subdocuments on the `Event` model. It introduces ticket expiry defaults, manual expiry overrides, ticket quantity safeguards, and admin routes for creating, updating, and deleting ticket types. It also enforces that paid events cannot be published until at least one active ticket type exists.

## Key changes
- Add embedded `ticketTypes[]` to the `Event` schema with name, price, max quantity, sold count, expiry, expiry source, and active status.
- Add `eventTicketService` for default expiry calculation, ticket deletion rules, update guards, paid-event publish checks, and purchasability checks.
- Add model helpers for adding, updating, and deleting embedded ticket types.
- Add admin ticket type routes under `/admin/events/:id/ticket-types`.
- Add Joi validation for ticket type create/update payloads.
- Prevent core event create/update endpoints from directly mutating ticket types.
- Add unit tests covering expiry defaults, manual expiry, deletion guards, max quantity guards, paid-event publish requirements, purchasability, and validator behavior.
