### PR TITLE
Link registration form builder to events via admin routes

### DIFF
--- a/src/controllers/events.admin.controller.js
+++ b/src/controllers/events.admin.controller.js
@@ -5,12 +5,22 @@ import {
   deleteEventTicketType,
   getEventById,
   getPaginatedEvents,
+  setEventRegistrationForm,
   updateEvent,
   updateEventTicketType,
   updateEventStatus,
 } from "../models/event.model.js";
+import {
+  createFormSchema,
+  getFormSchemaById,
+  updateFormSchema,
+} from "../models/formSchema.model.js";
 import { deleteAssets } from "../config/cloudinary.js";
 import logger from "../config/logger.js";
+import {
+  assertEventSupportsRegistrationForm,
+  getLinkedFormId,
+} from "../services/eventFormService.js";
 import { assertEventStatusTransition } from "../services/eventStatusService.js";
 import {
   assertCanDeleteTicketType,
@@ -294,6 +304,85 @@ export async function deleteEventTicketTypeAdmin(req, res) {
   } catch (error) {
     logger.error(
       `[events.admin.controller] Error deleting ticket type ${req.params.ticketTypeId}: ${error.message}`
+    );
+    res.status(error.message === "Event not found" ? 404 : 400).json(
+      formatResponse({
+        success: false,
+        error: error.message,
+      })
+    );
+  }
+}
+
+export async function upsertEventRegistrationFormAdmin(req, res) {
+  try {
+    const event = await getEventById(req.params.id);
+    assertEventSupportsRegistrationForm(event);
+
+    const existingFormId = getLinkedFormId(event);
+    const registrationForm = existingFormId
+      ? await updateFormSchema(existingFormId, { ...req.body })
+      : await createFormSchema(req.body, req.user._id);
+
+    const updatedEvent = existingFormId
+      ? event
+      : await setEventRegistrationForm(req.params.id, registrationForm._id);
+
+    res.status(existingFormId ? 200 : 201).json(
+      formatResponse({
+        message: "Registration form configured successfully",
+        data: {
+          event: updatedEvent,
+          registrationForm,
+        },
+      })
+    );
+  } catch (error) {
+    logger.error(
+      `[events.admin.controller] Error configuring registration form for event ${req.params.id}: ${error.message}`
+    );
+    res.status(error.message === "Event not found" ? 404 : 400).json(
+      formatResponse({
+        success: false,
+        error: error.message,
+      })
+    );
+  }
+}
+
+export async function getEventRegistrationFormAdmin(req, res) {
+  try {
+    const event = await getEventById(req.params.id);
+    assertEventSupportsRegistrationForm(event);
+
+    const registrationFormId = getLinkedFormId(event);
+    if (!registrationFormId) {
+      return res.status(404).json(
+        formatResponse({
+          success: false,
+          error: "Registration form not configured",
+        })
+      );
+    }
+
+    const registrationForm = await getFormSchemaById(registrationFormId);
+    if (!registrationForm) {
+      return res.status(404).json(
+        formatResponse({
+          success: false,
+          error: "Registration form not found",
+        })
+      );
+    }
+
+    res.status(200).json(
+      formatResponse({
+        data: registrationForm,
+      })
+    );
+  } catch (error) {
+    logger.error(
+      `[events.admin.controller] Error loading registration form for event ${req.params.id}: ${error.message}`
     );
     res.status(error.message === "Event not found" ? 404 : 400).json(
       formatResponse({

--- a/src/middleware/validator.middleware.js
+++ b/src/middleware/validator.middleware.js
@@ -5,6 +5,7 @@ import { orderValidator } from "../validators/order.validator.js";
 import { newsletterValidator } from "../validators/newsletter.validator.js";
 import { contactValidator } from "../validators/contact.validator.js";
 import { bespokeValidator } from "../validators/bespoke.validator.js";
+import { formSchemaValidator } from "../validators/formSchema.validator.js";
 import {
   eventStatusValidator,
   eventTicketTypeValidator,
@@ -156,6 +157,23 @@ export function validateEventTicketType(req, res, next) {
     : eventTicketTypeValidator;
 
   const { error } = schema.validate(req.body, {
+    abortEarly: false,
+  });
+
+  if (error) {
+    return res.status(400).json(
+      formatResponse({
+        success: false,
+        errors: error.details.map(err => err.message),
+      })
+    );
+  }
+
+  next();
+}
+
+export function validateFormSchema(req, res, next) {
+  const { error } = formSchemaValidator.validate(req.body, {
     abortEarly: false,
   });
 

--- a/src/models/event.model.js
+++ b/src/models/event.model.js
@@ -25,7 +25,7 @@ export async function getEventById(id) {
       return null;
     }
 
-    return await Event.findById(id);
+    return await Event.findById(id).populate("registrationFormId");
   } catch (error) {
     logger.error(`[event.model] Error finding event ${id}: ${error.message}`);
     throw error;
@@ -119,6 +119,25 @@ export async function updateEventStatus(id, status) {
   } catch (error) {
     logger.error(
       `[event.model] Error updating event ${id} status: ${error.message}`
+    );
+    throw error;
+  }
+}
+
+export async function setEventRegistrationForm(id, formSchemaId) {
+  try {
+    if (!Types.ObjectId.isValid(id) || !Types.ObjectId.isValid(formSchemaId)) {
+      return null;
+    }
+
+    return await Event.findByIdAndUpdate(
+      id,
+      { registrationFormId: formSchemaId },
+      { new: true, runValidators: true }
+    ).populate("registrationFormId");
+  } catch (error) {
+    logger.error(
+      `[event.model] Error setting registration form for event ${id}: ${error.message}`
     );
     throw error;
   }

--- a/src/models/event.mongo.js
+++ b/src/models/event.mongo.js
@@ -126,6 +126,11 @@ const eventSchema = new Schema(
       type: [ticketTypeSchema],
       default: [],
     },
+    registrationFormId: {
+      type: Schema.Types.ObjectId,
+      ref: "FormSchema",
+      default: null,
+    },
     createdBy: {
       type: Schema.Types.ObjectId,
       ref: "User",

--- a/src/routes/admin.routes.js
+++ b/src/routes/admin.routes.js
@@ -5,6 +5,7 @@ import {
   validateEvent,
   validateEventStatus,
   validateEventTicketType,
+  validateFormSchema,
   validateProduct,
   validateVariantProduct,
 } from "../middleware/validator.middleware.js";
@@ -34,10 +35,12 @@ import {
   addEventTicketTypeAdmin,
   deleteEventTicketTypeAdmin,
   getEventByIdAdmin,
+  getEventRegistrationFormAdmin,
   getEventsAdmin,
   updateEventAdmin,
   updateEventTicketTypeAdmin,
   updateEventStatusAdmin,
+  upsertEventRegistrationFormAdmin,
 } from "../controllers/events.admin.controller.js";
 import {
   getAllOrdersAdmin,
@@ -172,6 +175,21 @@ router.patch(
   checkAdmin,
   validateEventStatus,
   updateEventStatusAdmin
+);
+
+router.put(
+  "/events/:id/registration-form",
+  authenticateToken,
+  checkAdmin,
+  validateFormSchema,
+  upsertEventRegistrationFormAdmin
+);
+
+router.get(
+  "/events/:id/registration-form",
+  authenticateToken,
+  checkAdmin,
+  getEventRegistrationFormAdmin
 );
 
 router.post(

--- a/src/services/eventFormService.js
+++ b/src/services/eventFormService.js
@@ -1,0 +1,29 @@
+export function assertEventSupportsRegistrationForm(event) {
+  if (!event) {
+    throw new Error("Event not found");
+  }
+
+  if (!["free", "paid"].includes(event.type)) {
+    throw new Error("Registration forms can only be configured for events");
+  }
+
+  return true;
+}
+
+export function getLinkedFormId(event, formKey = "registrationFormId") {
+  const linkedForm = event?.[formKey];
+
+  if (!linkedForm) {
+    return null;
+  }
+
+  if (typeof linkedForm === "object" && linkedForm._id) {
+    return linkedForm._id.toString();
+  }
+
+  return linkedForm.toString();
+}
+
+export function hasLinkedForm(event, formKey = "registrationFormId") {
+  return Boolean(getLinkedFormId(event, formKey));
+}

--- a/tests/public/events/eventFormService.test.js
+++ b/tests/public/events/eventFormService.test.js
@@ -1,0 +1,43 @@
+/*eslint-disable no-undef */
+import {
+  assertEventSupportsRegistrationForm,
+  getLinkedFormId,
+  hasLinkedForm,
+} from "../../../src/services/eventFormService.js";
+
+describe("eventFormService", () => {
+  it("allows registration forms for free and paid events", () => {
+    expect(() =>
+      assertEventSupportsRegistrationForm({ type: "free" })
+    ).not.toThrow();
+    expect(() =>
+      assertEventSupportsRegistrationForm({ type: "paid" })
+    ).not.toThrow();
+  });
+
+  it("throws when the event is missing", () => {
+    expect(() => assertEventSupportsRegistrationForm(null)).toThrow(
+      "Event not found"
+    );
+  });
+
+  it("extracts linked form IDs from object or string references", () => {
+    const objectId = {
+      toString: () => "64a000000000000000000001",
+    };
+
+    expect(
+      getLinkedFormId({ registrationFormId: { _id: objectId } })
+    ).toBe("64a000000000000000000001");
+    expect(
+      getLinkedFormId({ registrationFormId: "64a000000000000000000002" })
+    ).toBe("64a000000000000000000002");
+  });
+
+  it("reports whether an event already has a linked form", () => {
+    expect(
+      hasLinkedForm({ registrationFormId: "64a000000000000000000002" })
+    ).toBe(true);
+    expect(hasLinkedForm({ registrationFormId: null })).toBe(false);
+  });
+});

--- a/tests/public/forms/formValidationService.test.js
+++ b/tests/public/forms/formValidationService.test.js
@@ -138,4 +138,43 @@ describe("formValidationService", () => {
     expect(result.valid).toBe(false);
     expect(result.errors).toContain("email is invalid");
   });
+
+  it("validates the same registration form schema for free and paid event responses", () => {
+    const registrationForm = {
+      builtinFields: [
+        { field: "name", required: true },
+        { field: "email", required: true },
+      ],
+      customQuestions: [
+        {
+          id: "attendanceReason",
+          label: "Why are you attending?",
+          type: "text",
+          required: true,
+        },
+      ],
+    };
+
+    const freeEventResponse = validateFormResponses(registrationForm, {
+      builtinFields: {
+        name: "Ama",
+        email: "ama@example.com",
+      },
+      customAnswers: {
+        attendanceReason: "To learn",
+      },
+    });
+    const paidEventResponse = validateFormResponses(registrationForm, {
+      builtinFields: {
+        name: "Kojo",
+        email: "kojo@example.com",
+      },
+      customAnswers: {
+        attendanceReason: "Networking",
+      },
+    });
+
+    expect(freeEventResponse.valid).toBe(true);
+    expect(paidEventResponse.valid).toBe(true);
+  });
 });


### PR DESCRIPTION
## Description
This branch connects the dynamic form builder foundation to events by allowing admins to configure registration forms per event. It adds a registration form reference on events, admin endpoints to create or update the linked form schema, and a route to retrieve the current form configuration. This unblocks attendee and checkout flows that need to collect event-specific registration details.

## Key changes
- Add `registrationFormId` to the `Event` model as a reference to `FormSchema`.
- Add model support for setting and populating an event’s registration form.
- Add `eventFormService` helpers for checking supported event types and extracting linked form IDs.
- Add admin `PUT` and `GET` routes for event registration form configuration.
- Reuse `formSchemaValidator` through new `validateFormSchema` middleware.
- Add controller logic to create a new form schema when none is linked, or update the existing linked form schema.
- Add unit tests for free/paid registration form support, linked form ID handling, and shared form validation for event registration flows.