### PR TITLE
Add volunteer form configuration and admin application review routes

### DIFF
--- a/src/controllers/events.admin.controller.js
+++ b/src/controllers/events.admin.controller.js
@@ -6,6 +6,7 @@ import {
   getEventById,
   getPaginatedEvents,
   setEventRegistrationForm,
+  setEventVolunteerForm,
   updateEvent,
   updateEventTicketType,
   updateEventStatus,
@@ -15,6 +16,12 @@ import {
   getFormSchemaById,
   updateFormSchema,
 } from "../models/formSchema.model.js";
+import {
+  countVolunteerApplications,
+  getPaginatedVolunteerApplications,
+  getVolunteerApplicationById,
+  updateVolunteerApplicationStatus,
+} from "../models/volunteerApplication.model.js";
 import { deleteAssets } from "../config/cloudinary.js";
 import logger from "../config/logger.js";
 import {
@@ -29,6 +36,7 @@ import {
   assertPaidEventSupportsTickets,
   buildTicketTypePayload,
 } from "../services/eventTicketService.js";
+import { assertVolunteerApplicationStatusTransition } from "../services/volunteerApplicationService.js";
 import { formatResponse } from "../utils/responseFormatter.js";
 
 export async function createEventAdmin(req, res) {
@@ -385,6 +393,212 @@ export async function getEventRegistrationFormAdmin(req, res) {
       `[events.admin.controller] Error loading registration form for event ${req.params.id}: ${error.message}`
     );
     res.status(error.message === "Event not found" ? 404 : 400).json(
+      formatResponse({
+        success: false,
+        error: error.message,
+      })
+    );
+  }
+}
+
+export async function upsertEventVolunteerFormAdmin(req, res) {
+  try {
+    const event = await getEventById(req.params.id);
+    assertEventSupportsRegistrationForm(event);
+
+    const existingFormId = getLinkedFormId(event, "volunteerFormId");
+    const volunteerForm = existingFormId
+      ? await updateFormSchema(existingFormId, { ...req.body })
+      : await createFormSchema(req.body, req.user._id);
+
+    const updatedEvent = existingFormId
+      ? event
+      : await setEventVolunteerForm(req.params.id, volunteerForm._id);
+
+    res.status(existingFormId ? 200 : 201).json(
+      formatResponse({
+        message: "Volunteer form configured successfully",
+        data: {
+          event: updatedEvent,
+          volunteerForm,
+        },
+      })
+    );
+  } catch (error) {
+    logger.error(
+      `[events.admin.controller] Error configuring volunteer form for event ${req.params.id}: ${error.message}`
+    );
+    res.status(error.message === "Event not found" ? 404 : 400).json(
+      formatResponse({
+        success: false,
+        error: error.message,
+      })
+    );
+  }
+}
+
+export async function getEventVolunteerFormAdmin(req, res) {
+  try {
+    const event = await getEventById(req.params.id);
+    assertEventSupportsRegistrationForm(event);
+
+    const volunteerFormId = getLinkedFormId(event, "volunteerFormId");
+    if (!volunteerFormId) {
+      return res.status(404).json(
+        formatResponse({
+          success: false,
+          error: "Volunteer form not configured",
+        })
+      );
+    }
+
+    const volunteerForm = await getFormSchemaById(volunteerFormId);
+    if (!volunteerForm) {
+      return res.status(404).json(
+        formatResponse({
+          success: false,
+          error: "Volunteer form not found",
+        })
+      );
+    }
+
+    res.status(200).json(formatResponse({ data: volunteerForm }));
+  } catch (error) {
+    logger.error(
+      `[events.admin.controller] Error loading volunteer form for event ${req.params.id}: ${error.message}`
+    );
+    res.status(error.message === "Event not found" ? 404 : 400).json(
+      formatResponse({
+        success: false,
+        error: error.message,
+      })
+    );
+  }
+}
+
+export async function getVolunteerApplicationsAdmin(req, res) {
+  try {
+    const event = await getEventById(req.params.id);
+    if (!event) {
+      return res.status(404).json(
+        formatResponse({
+          success: false,
+          error: "Event not found",
+        })
+      );
+    }
+
+    const { page, limit, status } = req.query;
+    const pageNum = Math.max(parseInt(page) || 1, 1);
+    const limitNum = Math.max(parseInt(limit) || 10, 1);
+    const filters = { status: status?.trim() || undefined };
+    const total = await countVolunteerApplications(req.params.id, filters);
+
+    if (pageNum > Math.ceil(total / limitNum) && total > 0) {
+      return res.status(400).json(
+        formatResponse({
+          success: false,
+          error: "Requested page exceeds available volunteer application pages",
+        })
+      );
+    }
+
+    const applications = await getPaginatedVolunteerApplications(
+      req.params.id,
+      pageNum,
+      limitNum,
+      filters
+    );
+
+    res.status(200).json(
+      formatResponse({
+        data: applications,
+        total,
+        totalPages: Math.ceil(total / limitNum),
+        currentPage: pageNum,
+      })
+    );
+  } catch (error) {
+    logger.error(
+      `[events.admin.controller] Error listing volunteer applications for event ${req.params.id}: ${error.message}`
+    );
+    res.status(500).json(
+      formatResponse({
+        success: false,
+        error: "Failed to load volunteer applications",
+      })
+    );
+  }
+}
+
+export async function getVolunteerApplicationByIdAdmin(req, res) {
+  try {
+    const application = await getVolunteerApplicationById(
+      req.params.id,
+      req.params.applicationId
+    );
+
+    if (!application) {
+      return res.status(404).json(
+        formatResponse({
+          success: false,
+          error: "Volunteer application not found",
+        })
+      );
+    }
+
+    res.status(200).json(formatResponse({ data: application }));
+  } catch (error) {
+    logger.error(
+      `[events.admin.controller] Error loading volunteer application ${req.params.applicationId}: ${error.message}`
+    );
+    res.status(500).json(
+      formatResponse({
+        success: false,
+        error: "Failed to load volunteer application",
+      })
+    );
+  }
+}
+
+export async function updateVolunteerApplicationStatusAdmin(req, res) {
+  try {
+    const application = await getVolunteerApplicationById(
+      req.params.id,
+      req.params.applicationId
+    );
+
+    if (!application) {
+      return res.status(404).json(
+        formatResponse({
+          success: false,
+          error: "Volunteer application not found",
+        })
+      );
+    }
+
+    assertVolunteerApplicationStatusTransition(
+      application.status,
+      req.body.status
+    );
+
+    const updatedApplication = await updateVolunteerApplicationStatus(
+      req.params.id,
+      req.params.applicationId,
+      req.body.status
+    );
+
+    res.status(200).json(
+      formatResponse({
+        message: "Volunteer application status updated successfully",
+        data: updatedApplication,
+      })
+    );
+  } catch (error) {
+    logger.error(
+      `[events.admin.controller] Error updating volunteer application ${req.params.applicationId}: ${error.message}`
+    );
+    res.status(400).json(
       formatResponse({
         success: false,
         error: error.message,

--- a/src/middleware/validator.middleware.js
+++ b/src/middleware/validator.middleware.js
@@ -11,6 +11,7 @@ import {
   eventTicketTypeValidator,
   eventValidator,
 } from "../validators/event.validator.js";
+import { volunteerApplicationStatusValidator } from "../validators/volunteerApplication.validator.js";
 import { formatResponse } from "../utils/responseFormatter.js";
 
 export function validateUser(req, res, next) {
@@ -174,6 +175,23 @@ export function validateEventTicketType(req, res, next) {
 
 export function validateFormSchema(req, res, next) {
   const { error } = formSchemaValidator.validate(req.body, {
+    abortEarly: false,
+  });
+
+  if (error) {
+    return res.status(400).json(
+      formatResponse({
+        success: false,
+        errors: error.details.map(err => err.message),
+      })
+    );
+  }
+
+  next();
+}
+
+export function validateVolunteerApplicationStatus(req, res, next) {
+  const { error } = volunteerApplicationStatusValidator.validate(req.body, {
     abortEarly: false,
   });
 

--- a/src/models/event.model.js
+++ b/src/models/event.model.js
@@ -6,6 +6,8 @@ export async function createEvent(eventData, adminId) {
   try {
     const payload = { ...eventData };
     delete payload.ticketTypes;
+    delete payload.registrationFormId;
+    delete payload.volunteerFormId;
 
     return await Event.create({
       ...payload,
@@ -25,7 +27,9 @@ export async function getEventById(id) {
       return null;
     }
 
-    return await Event.findById(id).populate("registrationFormId");
+    return await Event.findById(id)
+      .populate("registrationFormId")
+      .populate("volunteerFormId");
   } catch (error) {
     logger.error(`[event.model] Error finding event ${id}: ${error.message}`);
     throw error;
@@ -94,6 +98,8 @@ export async function updateEvent(id, updates) {
     delete updates.createdBy;
     delete updates.status;
     delete updates.ticketTypes;
+    delete updates.registrationFormId;
+    delete updates.volunteerFormId;
 
     return await Event.findByIdAndUpdate(id, updates, {
       new: true,
@@ -138,6 +144,25 @@ export async function setEventRegistrationForm(id, formSchemaId) {
   } catch (error) {
     logger.error(
       `[event.model] Error setting registration form for event ${id}: ${error.message}`
+    );
+    throw error;
+  }
+}
+
+export async function setEventVolunteerForm(id, formSchemaId) {
+  try {
+    if (!Types.ObjectId.isValid(id) || !Types.ObjectId.isValid(formSchemaId)) {
+      return null;
+    }
+
+    return await Event.findByIdAndUpdate(
+      id,
+      { volunteerFormId: formSchemaId },
+      { new: true, runValidators: true }
+    ).populate("volunteerFormId");
+  } catch (error) {
+    logger.error(
+      `[event.model] Error setting volunteer form for event ${id}: ${error.message}`
     );
     throw error;
   }

--- a/src/models/event.mongo.js
+++ b/src/models/event.mongo.js
@@ -131,6 +131,11 @@ const eventSchema = new Schema(
       ref: "FormSchema",
       default: null,
     },
+    volunteerFormId: {
+      type: Schema.Types.ObjectId,
+      ref: "FormSchema",
+      default: null,
+    },
     createdBy: {
       type: Schema.Types.ObjectId,
       ref: "User",

--- a/src/models/volunteerApplication.model.js
+++ b/src/models/volunteerApplication.model.js
@@ -1,0 +1,112 @@
+import { Types } from "mongoose";
+import logger from "../config/logger.js";
+import VolunteerApplication from "./volunteerApplication.mongo.js";
+
+export async function createVolunteerApplication(applicationData) {
+  try {
+    return await VolunteerApplication.create(applicationData);
+  } catch (error) {
+    logger.error(
+      `[volunteerApplication.model] Error creating volunteer application: ${error.message}`
+    );
+    throw error;
+  }
+}
+
+export async function getPaginatedVolunteerApplications(
+  eventId,
+  page = 1,
+  limit = 10,
+  params = {}
+) {
+  try {
+    if (!Types.ObjectId.isValid(eventId)) {
+      return [];
+    }
+
+    const filter = { event: eventId };
+    const skip = (page - 1) * limit;
+
+    if (params.status) {
+      filter.status = params.status;
+    }
+
+    return await VolunteerApplication.find(filter)
+      .sort({ createdAt: -1 })
+      .skip(skip)
+      .limit(limit);
+  } catch (error) {
+    logger.error(
+      `[volunteerApplication.model] Error listing volunteer applications for event ${eventId}: ${error.message}`
+    );
+    throw error;
+  }
+}
+
+export async function countVolunteerApplications(eventId, params = {}) {
+  try {
+    if (!Types.ObjectId.isValid(eventId)) {
+      return 0;
+    }
+
+    const filter = { event: eventId };
+
+    if (params.status) {
+      filter.status = params.status;
+    }
+
+    return await VolunteerApplication.countDocuments(filter);
+  } catch (error) {
+    logger.error(
+      `[volunteerApplication.model] Error counting volunteer applications for event ${eventId}: ${error.message}`
+    );
+    throw error;
+  }
+}
+
+export async function getVolunteerApplicationById(eventId, applicationId) {
+  try {
+    if (
+      !Types.ObjectId.isValid(eventId) ||
+      !Types.ObjectId.isValid(applicationId)
+    ) {
+      return null;
+    }
+
+    return await VolunteerApplication.findOne({
+      _id: applicationId,
+      event: eventId,
+    });
+  } catch (error) {
+    logger.error(
+      `[volunteerApplication.model] Error finding volunteer application ${applicationId}: ${error.message}`
+    );
+    throw error;
+  }
+}
+
+export async function updateVolunteerApplicationStatus(
+  eventId,
+  applicationId,
+  status
+) {
+  try {
+    if (
+      !Types.ObjectId.isValid(eventId) ||
+      !Types.ObjectId.isValid(applicationId)
+    ) {
+      return null;
+    }
+
+    return await VolunteerApplication.findOneAndUpdate(
+      { _id: applicationId, event: eventId },
+      { status },
+      { new: true, runValidators: true }
+    );
+  } catch (error) {
+    logger.error(
+      `[volunteerApplication.model] Error updating volunteer application ${applicationId}: ${error.message}`
+    );
+    throw error;
+  }
+}

--- a/src/models/volunteerApplication.mongo.js
+++ b/src/models/volunteerApplication.mongo.js
@@ -1,0 +1,70 @@
+import { Schema, model } from "mongoose";
+
+export const VOLUNTEER_APPLICATION_STATUSES = [
+  "pending",
+  "accepted",
+  "rejected",
+];
+
+const applicantInfoSchema = new Schema(
+  {
+    name: {
+      type: String,
+      trim: true,
+      default: "",
+    },
+    email: {
+      type: String,
+      trim: true,
+      lowercase: true,
+      default: "",
+    },
+    phone: {
+      type: String,
+      trim: true,
+      default: "",
+    },
+  },
+  { _id: false }
+);
+
+const volunteerApplicationSchema = new Schema(
+  {
+    event: {
+      type: Schema.Types.ObjectId,
+      ref: "Event",
+      required: true,
+      index: true,
+    },
+    applicantInfo: {
+      type: applicantInfoSchema,
+      default: () => ({}),
+    },
+    formResponses: {
+      builtinFields: {
+        type: Schema.Types.Mixed,
+        default: {},
+      },
+      customAnswers: {
+        type: Schema.Types.Mixed,
+        default: {},
+      },
+    },
+    status: {
+      type: String,
+      enum: VOLUNTEER_APPLICATION_STATUSES,
+      default: "pending",
+      index: true,
+    },
+  },
+  { timestamps: true }
+);
+
+volunteerApplicationSchema.index({ event: 1, status: 1, createdAt: -1 });
+
+const VolunteerApplication = model(
+  "VolunteerApplication",
+  volunteerApplicationSchema
+);
+
+export default VolunteerApplication;

--- a/src/routes/admin.routes.js
+++ b/src/routes/admin.routes.js
@@ -7,6 +7,7 @@ import {
   validateEventTicketType,
   validateFormSchema,
   validateProduct,
+  validateVolunteerApplicationStatus,
   validateVariantProduct,
 } from "../middleware/validator.middleware.js";
 import {
@@ -36,11 +37,16 @@ import {
   deleteEventTicketTypeAdmin,
   getEventByIdAdmin,
   getEventRegistrationFormAdmin,
+  getEventVolunteerFormAdmin,
   getEventsAdmin,
+  getVolunteerApplicationByIdAdmin,
+  getVolunteerApplicationsAdmin,
   updateEventAdmin,
   updateEventTicketTypeAdmin,
   updateEventStatusAdmin,
+  updateVolunteerApplicationStatusAdmin,
   upsertEventRegistrationFormAdmin,
+  upsertEventVolunteerFormAdmin,
 } from "../controllers/events.admin.controller.js";
 import {
   getAllOrdersAdmin,
@@ -190,6 +196,43 @@ router.get(
   authenticateToken,
   checkAdmin,
   getEventRegistrationFormAdmin
+);
+
+router.put(
+  "/events/:id/volunteer-form",
+  authenticateToken,
+  checkAdmin,
+  validateFormSchema,
+  upsertEventVolunteerFormAdmin
+);
+
+router.get(
+  "/events/:id/volunteer-form",
+  authenticateToken,
+  checkAdmin,
+  getEventVolunteerFormAdmin
+);
+
+router.get(
+  "/events/:id/volunteer-applications",
+  authenticateToken,
+  checkAdmin,
+  getVolunteerApplicationsAdmin
+);
+
+router.get(
+  "/events/:id/volunteer-applications/:applicationId",
+  authenticateToken,
+  checkAdmin,
+  getVolunteerApplicationByIdAdmin
+);
+
+router.patch(
+  "/events/:id/volunteer-applications/:applicationId",
+  authenticateToken,
+  checkAdmin,
+  validateVolunteerApplicationStatus,
+  updateVolunteerApplicationStatusAdmin
 );
 
 router.post(

--- a/src/services/volunteerApplicationService.js
+++ b/src/services/volunteerApplicationService.js
@@ -1,0 +1,43 @@
+export const VOLUNTEER_APPLICATION_STATUSES = [
+  "pending",
+  "accepted",
+  "rejected",
+];
+
+export const VOLUNTEER_APPLICATION_STATUS_TRANSITIONS = {
+  pending: ["accepted", "rejected"],
+  accepted: ["rejected"],
+  rejected: ["accepted"],
+};
+
+export function canTransitionVolunteerApplicationStatus(
+  currentStatus,
+  nextStatus
+) {
+  return (
+    VOLUNTEER_APPLICATION_STATUS_TRANSITIONS[currentStatus]?.includes(
+      nextStatus
+    ) ?? false
+  );
+}
+
+export function assertVolunteerApplicationStatusTransition(
+  currentStatus,
+  nextStatus
+) {
+  if (!VOLUNTEER_APPLICATION_STATUSES.includes(nextStatus)) {
+    throw new Error("Invalid volunteer application status");
+  }
+
+  if (currentStatus === nextStatus) {
+    return true;
+  }
+
+  if (!canTransitionVolunteerApplicationStatus(currentStatus, nextStatus)) {
+    throw new Error(
+      `Cannot transition volunteer application from ${currentStatus} to ${nextStatus}`
+    );
+  }
+
+  return true;
+}

--- a/src/validators/volunteerApplication.validator.js
+++ b/src/validators/volunteerApplication.validator.js
@@ -1,0 +1,8 @@
+import Joi from "joi";
+import { VOLUNTEER_APPLICATION_STATUSES } from "../models/volunteerApplication.mongo.js";
+
+export const volunteerApplicationStatusValidator = Joi.object({
+  status: Joi.string()
+    .valid(...VOLUNTEER_APPLICATION_STATUSES)
+    .required(),
+});

--- a/tests/public/events/eventFormService.test.js
+++ b/tests/public/events/eventFormService.test.js
@@ -32,11 +32,23 @@ describe("eventFormService", () => {
     expect(
       getLinkedFormId({ registrationFormId: "64a000000000000000000002" })
     ).toBe("64a000000000000000000002");
+    expect(
+      getLinkedFormId(
+        { volunteerFormId: "64a000000000000000000003" },
+        "volunteerFormId"
+      )
+    ).toBe("64a000000000000000000003");
   });
 
   it("reports whether an event already has a linked form", () => {
     expect(
       hasLinkedForm({ registrationFormId: "64a000000000000000000002" })
+    ).toBe(true);
+    expect(
+      hasLinkedForm(
+        { volunteerFormId: "64a000000000000000000003" },
+        "volunteerFormId"
+      )
     ).toBe(true);
     expect(hasLinkedForm({ registrationFormId: null })).toBe(false);
   });

--- a/tests/public/events/volunteerApplicationModel.test.js
+++ b/tests/public/events/volunteerApplicationModel.test.js
@@ -1,0 +1,53 @@
+/*eslint-disable no-undef */
+import { Types } from "mongoose";
+import VolunteerApplication from "../../../src/models/volunteerApplication.mongo.js";
+
+describe("VolunteerApplication model", () => {
+  it("stores applicant info, form responses, and pending status by default", () => {
+    const application = new VolunteerApplication({
+      event: new Types.ObjectId(),
+      applicantInfo: {
+        name: "Ama",
+        email: "AMA@EXAMPLE.COM",
+        phone: "0240000000",
+      },
+      formResponses: {
+        builtinFields: {
+          name: "Ama",
+          email: "ama@example.com",
+        },
+        customAnswers: {
+          availability: "Weekends",
+          hasExperience: true,
+        },
+      },
+    });
+
+    const validationError = application.validateSync();
+
+    expect(validationError).toBeUndefined();
+    expect(application.status).toBe("pending");
+    expect(application.applicantInfo.email).toBe("ama@example.com");
+    expect(application.formResponses.builtinFields).toEqual({
+      name: "Ama",
+      email: "ama@example.com",
+    });
+    expect(application.formResponses.customAnswers).toEqual({
+      availability: "Weekends",
+      hasExperience: true,
+    });
+  });
+
+  it("rejects unsupported statuses", () => {
+    const application = new VolunteerApplication({
+      event: new Types.ObjectId(),
+      status: "archived",
+    });
+
+    const validationError = application.validateSync();
+
+    expect(validationError.errors.status.message).toContain(
+      "`archived` is not a valid enum value"
+    );
+  });
+});

--- a/tests/public/events/volunteerApplicationService.test.js
+++ b/tests/public/events/volunteerApplicationService.test.js
@@ -1,0 +1,37 @@
+/*eslint-disable no-undef */
+import {
+  assertVolunteerApplicationStatusTransition,
+  canTransitionVolunteerApplicationStatus,
+} from "../../../src/services/volunteerApplicationService.js";
+
+describe("volunteerApplicationService", () => {
+  it("allows pending applications to be accepted or rejected", () => {
+    expect(canTransitionVolunteerApplicationStatus("pending", "accepted")).toBe(
+      true
+    );
+    expect(canTransitionVolunteerApplicationStatus("pending", "rejected")).toBe(
+      true
+    );
+  });
+
+  it("allows reviewed applications to be reclassified", () => {
+    expect(
+      canTransitionVolunteerApplicationStatus("accepted", "rejected")
+    ).toBe(true);
+    expect(
+      canTransitionVolunteerApplicationStatus("rejected", "accepted")
+    ).toBe(true);
+  });
+
+  it("throws for invalid volunteer application statuses", () => {
+    expect(() =>
+      assertVolunteerApplicationStatusTransition("pending", "archived")
+    ).toThrow("Invalid volunteer application status");
+  });
+
+  it("throws for unsupported transitions", () => {
+    expect(() =>
+      assertVolunteerApplicationStatusTransition("accepted", "pending")
+    ).toThrow("Cannot transition volunteer application from accepted to pending");
+  });
+});

--- a/tests/public/events/volunteerApplicationValidator.test.js
+++ b/tests/public/events/volunteerApplicationValidator.test.js
@@ -1,0 +1,22 @@
+/*eslint-disable no-undef */
+import { volunteerApplicationStatusValidator } from "../../../src/validators/volunteerApplication.validator.js";
+
+describe("volunteerApplication.validator", () => {
+  it("accepts supported volunteer application statuses", () => {
+    expect(
+      volunteerApplicationStatusValidator.validate({ status: "pending" }).error
+    ).toBeUndefined();
+    expect(
+      volunteerApplicationStatusValidator.validate({ status: "accepted" }).error
+    ).toBeUndefined();
+    expect(
+      volunteerApplicationStatusValidator.validate({ status: "rejected" }).error
+    ).toBeUndefined();
+  });
+
+  it("rejects unsupported volunteer application statuses", () => {
+    expect(
+      volunteerApplicationStatusValidator.validate({ status: "archived" }).error
+    ).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Description
This branch adds the volunteer portal foundation for events. It lets admins configure a reusable dynamic volunteer form per event and review submitted volunteer applications through event-scoped admin routes. The application model stores applicant details, submitted form responses, and review status so future public volunteer submission routes can plug into the same flow.

## Key changes
- Add `volunteerFormId` to the `Event` model as a `FormSchema` reference.
- Add `VolunteerApplication` model with event reference, applicant info, form responses, and `pending/accepted/rejected` status.
- Add volunteer application model helpers for listing, counting, fetching, creating, and status updates.
- Add volunteer application status transition service and Joi status validator.
- Add admin routes for volunteer form configuration and volunteer application review.
- Reuse existing form schema validation for volunteer form configuration.
- Prevent core event create/update from directly mutating linked form references.
- Add unit tests for volunteer form IDs, application status transitions, stored response shape, and status validation.
