### PR TITLE
 Add event registration model and admin attendee listing with capacity checks

### DIFF
--- a/src/controllers/events.admin.controller.js
+++ b/src/controllers/events.admin.controller.js
@@ -17,6 +17,11 @@ import {
   updateFormSchema,
 } from "../models/formSchema.model.js";
 import {
+  countEventRegistrations,
+  getEventRegistrationById,
+  getPaginatedEventRegistrations,
+} from "../models/eventRegistration.model.js";
+import {
   countVolunteerApplications,
   getPaginatedVolunteerApplications,
   getVolunteerApplicationById,
@@ -602,6 +607,94 @@ export async function updateVolunteerApplicationStatusAdmin(req, res) {
       formatResponse({
         success: false,
         error: error.message,
+      })
+    );
+  }
+}
+
+export async function getEventAttendeesAdmin(req, res) {
+  try {
+    const event = await getEventById(req.params.id);
+    if (!event) {
+      return res.status(404).json(
+        formatResponse({
+          success: false,
+          error: "Event not found",
+        })
+      );
+    }
+
+    const { page, limit, status, ticketTypeId } = req.query;
+    const pageNum = Math.max(parseInt(page) || 1, 1);
+    const limitNum = Math.max(parseInt(limit) || 10, 1);
+    const filters = {
+      status: status?.trim() || undefined,
+      ticketTypeId: ticketTypeId?.trim() || undefined,
+    };
+    const total = await countEventRegistrations(req.params.id, filters);
+
+    if (pageNum > Math.ceil(total / limitNum) && total > 0) {
+      return res.status(400).json(
+        formatResponse({
+          success: false,
+          error: "Requested page exceeds available attendee pages",
+        })
+      );
+    }
+
+    const attendees = await getPaginatedEventRegistrations(
+      req.params.id,
+      pageNum,
+      limitNum,
+      filters
+    );
+
+    res.status(200).json(
+      formatResponse({
+        data: attendees,
+        total,
+        totalPages: Math.ceil(total / limitNum),
+        currentPage: pageNum,
+      })
+    );
+  } catch (error) {
+    logger.error(
+      `[events.admin.controller] Error listing attendees for event ${req.params.id}: ${error.message}`
+    );
+    res.status(500).json(
+      formatResponse({
+        success: false,
+        error: "Failed to load attendees",
+      })
+    );
+  }
+}
+
+export async function getEventAttendeeByIdAdmin(req, res) {
+  try {
+    const attendee = await getEventRegistrationById(
+      req.params.id,
+      req.params.registrationId
+    );
+
+    if (!attendee) {
+      return res.status(404).json(
+        formatResponse({
+          success: false,
+          error: "Attendee not found",
+        })
+      );
+    }
+
+    res.status(200).json(formatResponse({ data: attendee }));
+  } catch (error) {
+    logger.error(
+      `[events.admin.controller] Error loading attendee ${req.params.registrationId}: ${error.message}`
+    );
+    res.status(500).json(
+      formatResponse({
+        success: false,
+        error: "Failed to load attendee",
       })
     );
   }

--- a/src/models/eventRegistration.model.js
+++ b/src/models/eventRegistration.model.js
@@ -1,0 +1,105 @@
+import { Types } from "mongoose";
+import logger from "../config/logger.js";
+import EventRegistration from "./eventRegistration.mongo.js";
+
+export async function createEventRegistration(registrationData) {
+  try {
+    return await EventRegistration.create(registrationData);
+  } catch (error) {
+    logger.error(
+      `[eventRegistration.model] Error creating event registration: ${error.message}`
+    );
+    throw error;
+  }
+}
+
+export async function getPaginatedEventRegistrations(
+  eventId,
+  page = 1,
+  limit = 10,
+  params = {}
+) {
+  try {
+    if (!Types.ObjectId.isValid(eventId)) {
+      return [];
+    }
+
+    const filter = { event: eventId };
+    const skip = (page - 1) * limit;
+
+    if (params.status) {
+      filter.status = params.status;
+    }
+
+    if (params.ticketTypeId && Types.ObjectId.isValid(params.ticketTypeId)) {
+      filter.ticketTypeId = params.ticketTypeId;
+    }
+
+    return await EventRegistration.find(filter)
+      .sort({ createdAt: -1 })
+      .skip(skip)
+      .limit(limit)
+      .populate({ path: "user", select: "displayName email contact" })
+      .populate({ path: "transaction", select: "reference amount status" });
+  } catch (error) {
+    logger.error(
+      `[eventRegistration.model] Error listing registrations for event ${eventId}: ${error.message}`
+    );
+    throw error;
+  }
+}
+
+export async function countEventRegistrations(eventId, params = {}) {
+  try {
+    if (!Types.ObjectId.isValid(eventId)) {
+      return 0;
+    }
+
+    const filter = { event: eventId };
+
+    if (params.status) {
+      filter.status = params.status;
+    }
+
+    if (params.ticketTypeId && Types.ObjectId.isValid(params.ticketTypeId)) {
+      filter.ticketTypeId = params.ticketTypeId;
+    }
+
+    return await EventRegistration.countDocuments(filter);
+  } catch (error) {
+    logger.error(
+      `[eventRegistration.model] Error counting registrations for event ${eventId}: ${error.message}`
+    );
+    throw error;
+  }
+}
+
+export async function countConfirmedRegistrations(eventId, params = {}) {
+  return countEventRegistrations(eventId, {
+    ...params,
+    status: "confirmed",
+  });
+}
+
+export async function getEventRegistrationById(eventId, registrationId) {
+  try {
+    if (
+      !Types.ObjectId.isValid(eventId) ||
+      !Types.ObjectId.isValid(registrationId)
+    ) {
+      return null;
+    }
+
+    return await EventRegistration.findOne({
+      _id: registrationId,
+      event: eventId,
+    })
+      .populate({ path: "user", select: "displayName email contact" })
+      .populate({ path: "transaction", select: "reference amount status" });
+  } catch (error) {
+    logger.error(
+      `[eventRegistration.model] Error finding registration ${registrationId}: ${error.message}`
+    );
+    throw error;
+  }
+}

--- a/src/models/eventRegistration.mongo.js
+++ b/src/models/eventRegistration.mongo.js
@@ -1,0 +1,84 @@
+import { Schema, model } from "mongoose";
+
+export const EVENT_REGISTRATION_STATUSES = [
+  "pending",
+  "confirmed",
+  "cancelled",
+];
+
+const guestInfoSchema = new Schema(
+  {
+    name: {
+      type: String,
+      trim: true,
+      default: "",
+    },
+    email: {
+      type: String,
+      trim: true,
+      lowercase: true,
+      default: "",
+    },
+    phone: {
+      type: String,
+      trim: true,
+      default: "",
+    },
+  },
+  { _id: false }
+);
+
+const eventRegistrationSchema = new Schema(
+  {
+    event: {
+      type: Schema.Types.ObjectId,
+      ref: "Event",
+      required: true,
+      index: true,
+    },
+    user: {
+      type: Schema.Types.ObjectId,
+      ref: "User",
+      default: null,
+      index: true,
+    },
+    guestInfo: {
+      type: guestInfoSchema,
+      default: () => ({}),
+    },
+    formResponses: {
+      builtinFields: {
+        type: Schema.Types.Mixed,
+        default: {},
+      },
+      customAnswers: {
+        type: Schema.Types.Mixed,
+        default: {},
+      },
+    },
+    ticketTypeId: {
+      type: Schema.Types.ObjectId,
+      default: null,
+      index: true,
+    },
+    status: {
+      type: String,
+      enum: EVENT_REGISTRATION_STATUSES,
+      default: "confirmed",
+      index: true,
+    },
+    transaction: {
+      type: Schema.Types.ObjectId,
+      ref: "Transaction",
+      default: null,
+    },
+  },
+  { timestamps: true }
+);
+
+eventRegistrationSchema.index({ event: 1, status: 1, createdAt: -1 });
+eventRegistrationSchema.index({ event: 1, ticketTypeId: 1, status: 1 });
+
+const EventRegistration = model("EventRegistration", eventRegistrationSchema);
+
+export default EventRegistration;

--- a/src/routes/admin.routes.js
+++ b/src/routes/admin.routes.js
@@ -35,6 +35,8 @@ import {
   createEventAdmin,
   addEventTicketTypeAdmin,
   deleteEventTicketTypeAdmin,
+  getEventAttendeeByIdAdmin,
+  getEventAttendeesAdmin,
   getEventByIdAdmin,
   getEventRegistrationFormAdmin,
   getEventVolunteerFormAdmin,
@@ -233,6 +235,20 @@ router.patch(
   checkAdmin,
   validateVolunteerApplicationStatus,
   updateVolunteerApplicationStatusAdmin
+);
+
+router.get(
+  "/events/:id/attendees",
+  authenticateToken,
+  checkAdmin,
+  getEventAttendeesAdmin
+);
+
+router.get(
+  "/events/:id/attendees/:registrationId",
+  authenticateToken,
+  checkAdmin,
+  getEventAttendeeByIdAdmin
 );
 
 router.post(

--- a/src/services/eventCapacityLogic.js
+++ b/src/services/eventCapacityLogic.js
@@ -1,0 +1,57 @@
+export function assertEventAcceptsRegistrations(event) {
+  if (!event) {
+    throw new Error("Event not found");
+  }
+
+  if (event.status === "cancelled") {
+    throw new Error("Cancelled events do not accept registrations");
+  }
+}
+
+export function hasEventCapacity(
+  event,
+  additionalCount = 1,
+  confirmedCount = 0
+) {
+  if (!event) return false;
+
+  return Number(confirmedCount) + Number(additionalCount) <= event.maxAttendees;
+}
+
+export function getTicketTypeById(event, ticketTypeId) {
+  if (!event?.ticketTypes || !ticketTypeId) return null;
+
+  if (typeof event.ticketTypes.id === "function") {
+    return event.ticketTypes.id(ticketTypeId);
+  }
+
+  return (
+    event.ticketTypes.find(
+      ticketType => ticketType._id?.toString() === ticketTypeId.toString()
+    ) ?? null
+  );
+}
+
+export function hasTicketCapacity(ticketType, additionalCount = 1) {
+  if (!ticketType) return false;
+
+  const remaining =
+    Number(ticketType.maxQuantity ?? 0) - Number(ticketType.soldCount ?? 0);
+
+  return remaining >= Number(additionalCount);
+}
+
+export function checkCapacity(event, additionalCount = 1, options = {}) {
+  assertEventAcceptsRegistrations(event);
+
+  if (!hasEventCapacity(event, additionalCount, options.confirmedCount ?? 0)) {
+    return false;
+  }
+
+  if (options.ticketTypeId) {
+    const ticketType = getTicketTypeById(event, options.ticketTypeId);
+    return hasTicketCapacity(ticketType, additionalCount);
+  }
+
+  return true;
+}

--- a/src/services/eventCapacityService.js
+++ b/src/services/eventCapacityService.js
@@ -1,69 +1,32 @@
 import { countConfirmedRegistrations } from "../models/eventRegistration.model.js";
+import {
+  assertEventAcceptsRegistrations,
+  checkCapacity,
+  getTicketTypeById,
+  hasEventCapacity,
+  hasTicketCapacity,
+} from "./eventCapacityLogic.js";
+
+export {
+  assertEventAcceptsRegistrations,
+  getTicketTypeById,
+  hasEventCapacity,
+  hasTicketCapacity,
+};
 
 export async function getConfirmedCount(eventId, params = {}) {
   return countConfirmedRegistrations(eventId, params);
 }
 
-export function assertEventAcceptsRegistrations(event) {
-  if (!event) {
-    throw new Error("Event not found");
-  }
-
-  if (event.status === "cancelled") {
-    throw new Error("Cancelled events do not accept registrations");
-  }
-}
-
-export function hasEventCapacity(
-  event,
-  additionalCount = 1,
-  confirmedCount = 0
-) {
-  if (!event) return false;
-
-  return Number(confirmedCount) + Number(additionalCount) <= event.maxAttendees;
-}
-
-export function getTicketTypeById(event, ticketTypeId) {
-  if (!event?.ticketTypes || !ticketTypeId) return null;
-
-  if (typeof event.ticketTypes.id === "function") {
-    return event.ticketTypes.id(ticketTypeId);
-  }
-
-  return (
-    event.ticketTypes.find(
-      ticketType => ticketType._id?.toString() === ticketTypeId.toString()
-    ) ?? null
-  );
-}
-
-export function hasTicketCapacity(ticketType, additionalCount = 1) {
-  if (!ticketType) return false;
-
-  const remaining =
-    Number(ticketType.maxQuantity ?? 0) - Number(ticketType.soldCount ?? 0);
-
-  return remaining >= Number(additionalCount);
-}
-
 export async function hasCapacity(event, additionalCount = 1, options = {}) {
-  assertEventAcceptsRegistrations(event);
-
   const confirmedCount =
     options.confirmedCount ??
     (await getConfirmedCount(event._id ?? event.id, {
       ticketTypeId: options.ticketTypeId,
     }));
 
-  if (!hasEventCapacity(event, additionalCount, confirmedCount)) {
-    return false;
-  }
-
-  if (options.ticketTypeId) {
-    const ticketType = getTicketTypeById(event, options.ticketTypeId);
-    return hasTicketCapacity(ticketType, additionalCount);
-  }
-
-  return true;
+  return checkCapacity(event, additionalCount, {
+    ...options,
+    confirmedCount,
+  });
 }

--- a/src/services/eventCapacityService.js
+++ b/src/services/eventCapacityService.js
@@ -1,0 +1,69 @@
+import { countConfirmedRegistrations } from "../models/eventRegistration.model.js";
+
+export async function getConfirmedCount(eventId, params = {}) {
+  return countConfirmedRegistrations(eventId, params);
+}
+
+export function assertEventAcceptsRegistrations(event) {
+  if (!event) {
+    throw new Error("Event not found");
+  }
+
+  if (event.status === "cancelled") {
+    throw new Error("Cancelled events do not accept registrations");
+  }
+}
+
+export function hasEventCapacity(
+  event,
+  additionalCount = 1,
+  confirmedCount = 0
+) {
+  if (!event) return false;
+
+  return Number(confirmedCount) + Number(additionalCount) <= event.maxAttendees;
+}
+
+export function getTicketTypeById(event, ticketTypeId) {
+  if (!event?.ticketTypes || !ticketTypeId) return null;
+
+  if (typeof event.ticketTypes.id === "function") {
+    return event.ticketTypes.id(ticketTypeId);
+  }
+
+  return (
+    event.ticketTypes.find(
+      ticketType => ticketType._id?.toString() === ticketTypeId.toString()
+    ) ?? null
+  );
+}
+
+export function hasTicketCapacity(ticketType, additionalCount = 1) {
+  if (!ticketType) return false;
+
+  const remaining =
+    Number(ticketType.maxQuantity ?? 0) - Number(ticketType.soldCount ?? 0);
+
+  return remaining >= Number(additionalCount);
+}
+
+export async function hasCapacity(event, additionalCount = 1, options = {}) {
+  assertEventAcceptsRegistrations(event);
+
+  const confirmedCount =
+    options.confirmedCount ??
+    (await getConfirmedCount(event._id ?? event.id, {
+      ticketTypeId: options.ticketTypeId,
+    }));
+
+  if (!hasEventCapacity(event, additionalCount, confirmedCount)) {
+    return false;
+  }
+
+  if (options.ticketTypeId) {
+    const ticketType = getTicketTypeById(event, options.ticketTypeId);
+    return hasTicketCapacity(ticketType, additionalCount);
+  }
+
+  return true;
+}

--- a/tests/public/events/eventCapacityService.test.js
+++ b/tests/public/events/eventCapacityService.test.js
@@ -1,13 +1,13 @@
 /*eslint-disable no-undef */
 import {
   assertEventAcceptsRegistrations,
+  checkCapacity,
   getTicketTypeById,
-  hasCapacity,
   hasEventCapacity,
   hasTicketCapacity,
-} from "../../../src/services/eventCapacityService.js";
+} from "../../../src/services/eventCapacityLogic.js";
 
-describe("eventCapacityService", () => {
+describe("eventCapacityLogic", () => {
   const ticketTypeId = "64a000000000000000000001";
   const event = {
     _id: "64a000000000000000000010",
@@ -39,30 +39,30 @@ describe("eventCapacityService", () => {
     expect(getTicketTypeById(event, "64a000000000000000000002")).toBeNull();
   });
 
-  it("combines event-level and ticket-level capacity checks", async () => {
-    await expect(
-      hasCapacity(event, 2, {
+  it("combines event-level and ticket-level capacity checks", () => {
+    expect(
+      checkCapacity(event, 2, {
         confirmedCount: 8,
         ticketTypeId,
       })
-    ).resolves.toBe(true);
+    ).toBe(true);
 
-    await expect(
-      hasCapacity(event, 3, {
+    expect(
+      checkCapacity(event, 3, {
         confirmedCount: 7,
         ticketTypeId,
       })
-    ).resolves.toBe(false);
+    ).toBe(false);
   });
 
-  it("blocks cancelled events from accepting registrations", async () => {
+  it("blocks cancelled events from accepting registrations", () => {
     const cancelledEvent = { ...event, status: "cancelled" };
 
     expect(() => assertEventAcceptsRegistrations(cancelledEvent)).toThrow(
       "Cancelled events do not accept registrations"
     );
-    await expect(hasCapacity(cancelledEvent, 1, { confirmedCount: 0 })).rejects.toThrow(
-      "Cancelled events do not accept registrations"
-    );
+    expect(() =>
+      checkCapacity(cancelledEvent, 1, { confirmedCount: 0 })
+    ).toThrow("Cancelled events do not accept registrations");
   });
 });

--- a/tests/public/events/eventCapacityService.test.js
+++ b/tests/public/events/eventCapacityService.test.js
@@ -1,0 +1,68 @@
+/*eslint-disable no-undef */
+import {
+  assertEventAcceptsRegistrations,
+  getTicketTypeById,
+  hasCapacity,
+  hasEventCapacity,
+  hasTicketCapacity,
+} from "../../../src/services/eventCapacityService.js";
+
+describe("eventCapacityService", () => {
+  const ticketTypeId = "64a000000000000000000001";
+  const event = {
+    _id: "64a000000000000000000010",
+    status: "published",
+    maxAttendees: 10,
+    ticketTypes: [
+      {
+        _id: {
+          toString: () => ticketTypeId,
+        },
+        maxQuantity: 5,
+        soldCount: 3,
+      },
+    ],
+  };
+
+  it("checks event-level capacity using confirmed registration count", () => {
+    expect(hasEventCapacity(event, 2, 8)).toBe(true);
+    expect(hasEventCapacity(event, 3, 8)).toBe(false);
+  });
+
+  it("checks ticket-level capacity from max quantity and sold count", () => {
+    expect(hasTicketCapacity(event.ticketTypes[0], 2)).toBe(true);
+    expect(hasTicketCapacity(event.ticketTypes[0], 3)).toBe(false);
+  });
+
+  it("finds ticket types by embedded id", () => {
+    expect(getTicketTypeById(event, ticketTypeId)).toBe(event.ticketTypes[0]);
+    expect(getTicketTypeById(event, "64a000000000000000000002")).toBeNull();
+  });
+
+  it("combines event-level and ticket-level capacity checks", async () => {
+    await expect(
+      hasCapacity(event, 2, {
+        confirmedCount: 8,
+        ticketTypeId,
+      })
+    ).resolves.toBe(true);
+
+    await expect(
+      hasCapacity(event, 3, {
+        confirmedCount: 7,
+        ticketTypeId,
+      })
+    ).resolves.toBe(false);
+  });
+
+  it("blocks cancelled events from accepting registrations", async () => {
+    const cancelledEvent = { ...event, status: "cancelled" };
+
+    expect(() => assertEventAcceptsRegistrations(cancelledEvent)).toThrow(
+      "Cancelled events do not accept registrations"
+    );
+    await expect(hasCapacity(cancelledEvent, 1, { confirmedCount: 0 })).rejects.toThrow(
+      "Cancelled events do not accept registrations"
+    );
+  });
+});

--- a/tests/public/events/eventRegistrationModel.test.js
+++ b/tests/public/events/eventRegistrationModel.test.js
@@ -1,0 +1,65 @@
+/*eslint-disable no-undef */
+import { Types } from "mongoose";
+import EventRegistration from "../../../src/models/eventRegistration.mongo.js";
+
+describe("EventRegistration model", () => {
+  it("stores guest attendee details and form responses", () => {
+    const registration = new EventRegistration({
+      event: new Types.ObjectId(),
+      guestInfo: {
+        name: "Ama",
+        email: "AMA@EXAMPLE.COM",
+        phone: "0240000000",
+      },
+      formResponses: {
+        builtinFields: {
+          name: "Ama",
+          email: "ama@example.com",
+        },
+        customAnswers: {
+          dietary: "vegetarian",
+        },
+      },
+    });
+
+    const validationError = registration.validateSync();
+
+    expect(validationError).toBeUndefined();
+    expect(registration.status).toBe("confirmed");
+    expect(registration.guestInfo.email).toBe("ama@example.com");
+    expect(registration.formResponses.customAnswers).toEqual({
+      dietary: "vegetarian",
+    });
+  });
+
+  it("stores paid ticket and transaction references", () => {
+    const registration = new EventRegistration({
+      event: new Types.ObjectId(),
+      user: new Types.ObjectId(),
+      ticketTypeId: new Types.ObjectId(),
+      transaction: new Types.ObjectId(),
+      status: "pending",
+    });
+
+    const validationError = registration.validateSync();
+
+    expect(validationError).toBeUndefined();
+    expect(registration.user).toBeDefined();
+    expect(registration.ticketTypeId).toBeDefined();
+    expect(registration.transaction).toBeDefined();
+    expect(registration.status).toBe("pending");
+  });
+
+  it("rejects unsupported registration statuses", () => {
+    const registration = new EventRegistration({
+      event: new Types.ObjectId(),
+      status: "archived",
+    });
+
+    const validationError = registration.validateSync();
+
+    expect(validationError.errors.status.message).toContain(
+      "`archived` is not a valid enum value"
+    );
+  });
+});


### PR DESCRIPTION
## Description
This branch introduces attendee tracking for event registrations. It adds an `EventRegistration` model to store guest or user registrations, form responses, optional paid ticket metadata, and transaction references. It also adds reusable capacity checks and admin routes for viewing event attendees ahead of the checkout and RSVP flows.

## Key changes
- Add `EventRegistration` model with event, optional user, guest info, form responses, ticket type ID, status, and transaction reference.
- Add event registration model helpers for creating, listing, counting, counting confirmed attendees, and loading attendee details.
- Add `eventCapacityService` for confirmed attendee counts, event-level capacity checks, ticket-level capacity checks, and cancelled-event blocking.
- Add admin attendee list and detail routes under `/admin/events/:id/attendees`.
- Populate attendee user and transaction summaries in admin attendee reads.
- Add unit tests for attendee storage shape, paid ticket references, status validation, event capacity, ticket capacity, and cancelled event registration blocking.
