### PR TITLE
Extend Paystack checkout for event ticket purchases

### DIFF
--- a/src/controllers/events.admin.controller.js
+++ b/src/controllers/events.admin.controller.js
@@ -34,6 +34,7 @@ import {
   getLinkedFormId,
 } from "../services/eventFormService.js";
 import { assertEventStatusTransition } from "../services/eventStatusService.js";
+import { initializeEventTicketCheckout } from "../services/eventCheckoutService.js";
 import {
   assertCanDeleteTicketType,
   assertCanUpdateTicketType,
@@ -695,6 +696,41 @@ export async function getEventAttendeeByIdAdmin(req, res) {
       formatResponse({
         success: false,
         error: "Failed to load attendee",
+      })
+    );
+  }
+}
+
+export async function initializeEventTicketCheckoutAdmin(req, res) {
+  try {
+    const principal = {
+      type: "user",
+      _id: req.user._id,
+      user: req.user,
+    };
+    const checkout = await initializeEventTicketCheckout({
+      eventId: req.params.id,
+      principal,
+      ticketTypeId: req.body.ticketTypeId,
+      quantity: req.body.quantity,
+      guestInfo: req.body.guestInfo,
+      formResponses: req.body.formResponses,
+    });
+
+    res.status(200).json(
+      formatResponse({
+        message: "Event ticket payment initialized successfully",
+        data: checkout,
+      })
+    );
+  } catch (error) {
+    logger.error(
+      `[events.admin.controller] Error initializing event ticket checkout for event ${req.params.id}: ${error.message}`
+    );
+    res.status(error.message === "Event not found" ? 404 : 400).json(
+      formatResponse({
+        success: false,
+        error: error.message,
       })
     );
   }

--- a/src/controllers/payment.controller.js
+++ b/src/controllers/payment.controller.js
@@ -8,6 +8,10 @@ import {
   verifyWebhookSignature,
 } from "../services/paystackService.js";
 import {
+  cancelEventTicketRegistration,
+  confirmEventTicketPayment,
+} from "../services/eventCheckoutService.js";
+import {
   sendAdminNewOrderNotification,
   sendCustomerStatusUpdateNotification,
 } from "../services/orderEmailService.js";
@@ -120,10 +124,13 @@ async function handleSuccessfulPayment(data) {
       return;
     }
 
-    // Idempotent check: if order already exists, return early to prevent duplicates
-    if (transaction.status === "success" && transaction.order) {
+    // Idempotent check: if fulfillment already exists, return early to prevent duplicates
+    if (
+      transaction.status === "success" &&
+      (transaction.order || transaction.eventRegistration)
+    ) {
       logger.info(
-        `[payment.controller] Order already exists for transaction: ${reference}, Order: ${transaction.order}`
+        `[payment.controller] Payment already fulfilled for transaction: ${reference}`
       );
       return;
     }
@@ -148,6 +155,22 @@ async function handleSuccessfulPayment(data) {
         `[payment.controller] Paystack verification failed for reference: ${reference}`
       );
       await updateTransactionStatus(reference, "failed");
+      return;
+    }
+
+    if (transaction.purpose === "event_ticket") {
+      const registration = await confirmEventTicketPayment(transaction);
+      await updateTransactionStatus(
+        reference,
+        "success",
+        null,
+        verificationResult,
+        registration._id
+      );
+
+      logger.info(
+        `[payment.controller] Event ticket registration confirmed for transaction: ${reference}, Registration: ${registration._id}`
+      );
       return;
     }
 
@@ -242,6 +265,11 @@ async function handleFailedPayment(data) {
     const { reference } = data;
 
     // Update transaction status to failed
+    const transaction = await getTransactionByReference(reference);
+    if (transaction?.purpose === "event_ticket") {
+      await cancelEventTicketRegistration(transaction);
+    }
+
     await updateTransactionStatus(reference, "failed");
 
     logger.info(
@@ -324,6 +352,7 @@ export const verifyPayment = async (req, res) => {
               data: {
                 transaction: updatedTransaction,
                 order: updatedTransaction.order,
+                eventRegistration: updatedTransaction.eventRegistration,
               },
             })
           );
@@ -341,6 +370,7 @@ export const verifyPayment = async (req, res) => {
               data: {
                 transaction: updatedTransaction,
                 order: null,
+                eventRegistration: null,
               },
             })
           );
@@ -370,6 +400,7 @@ export const verifyPayment = async (req, res) => {
         data: {
           transaction,
           order: transaction.order,
+          eventRegistration: transaction.eventRegistration,
         },
       })
     );

--- a/src/middleware/validator.middleware.js
+++ b/src/middleware/validator.middleware.js
@@ -11,6 +11,7 @@ import {
   eventTicketTypeValidator,
   eventValidator,
 } from "../validators/event.validator.js";
+import { eventTicketCheckoutValidator } from "../validators/eventCheckout.validator.js";
 import { volunteerApplicationStatusValidator } from "../validators/volunteerApplication.validator.js";
 import { formatResponse } from "../utils/responseFormatter.js";
 
@@ -204,5 +205,23 @@ export function validateVolunteerApplicationStatus(req, res, next) {
     );
   }
 
+  next();
+}
+
+export function validateEventTicketCheckout(req, res, next) {
+  const { error, value } = eventTicketCheckoutValidator.validate(req.body, {
+    abortEarly: false,
+  });
+
+  if (error) {
+    return res.status(400).json(
+      formatResponse({
+        success: false,
+        errors: error.details.map(err => err.message),
+      })
+    );
+  }
+
+  req.body = value;
   next();
 }

--- a/src/models/event.model.js
+++ b/src/models/event.model.js
@@ -226,3 +226,26 @@ export async function deleteEventTicketType(id, ticketTypeId) {
     throw error;
   }
 }
+
+export async function incrementEventTicketSoldCount(
+  id,
+  ticketTypeId,
+  quantity
+) {
+  try {
+    if (!Types.ObjectId.isValid(id) || !Types.ObjectId.isValid(ticketTypeId)) {
+      return null;
+    }
+
+    return await Event.findOneAndUpdate(
+      { _id: id, "ticketTypes._id": ticketTypeId },
+      { $inc: { "ticketTypes.$.soldCount": quantity } },
+      { new: true, runValidators: true }
+    );
+  } catch (error) {
+    logger.error(
+      `[event.model] Error incrementing sold count for ticket type ${ticketTypeId} on event ${id}: ${error.message}`
+    );
+    throw error;
+  }
+}

--- a/src/models/eventRegistration.model.js
+++ b/src/models/eventRegistration.model.js
@@ -103,3 +103,45 @@ export async function getEventRegistrationById(eventId, registrationId) {
     throw error;
   }
 }
+
+export async function getEventRegistrationByIdOnly(registrationId) {
+  try {
+    if (!Types.ObjectId.isValid(registrationId)) {
+      return null;
+    }
+
+    return await EventRegistration.findById(registrationId)
+      .populate({ path: "user", select: "displayName email contact" })
+      .populate({ path: "transaction", select: "reference amount status" });
+  } catch (error) {
+    logger.error(
+      `[eventRegistration.model] Error finding registration ${registrationId}: ${error.message}`
+    );
+    throw error;
+  }
+}
+
+export async function updateEventRegistrationPayment(
+  registrationId,
+  { status, transactionId }
+) {
+  try {
+    if (!Types.ObjectId.isValid(registrationId)) {
+      return null;
+    }
+
+    const updates = {};
+    if (status) updates.status = status;
+    if (transactionId) updates.transaction = transactionId;
+
+    return await EventRegistration.findByIdAndUpdate(registrationId, updates, {
+      new: true,
+      runValidators: true,
+    });
+  } catch (error) {
+    logger.error(
+      `[eventRegistration.model] Error updating registration payment ${registrationId}: ${error.message}`
+    );
+    throw error;
+  }
+}

--- a/src/models/transaction.model.js
+++ b/src/models/transaction.model.js
@@ -16,10 +16,13 @@ export async function createTransaction(transactionData) {
 
 export async function getTransactionByReference(reference) {
   try {
-    const transaction = await Transaction.findOne({ reference }).populate({
-      path: "user",
-      select: "name email",
-    });
+    const transaction = await Transaction.findOne({ reference })
+      .populate({
+        path: "user",
+        select: "name email displayName isGuest",
+      })
+      .populate({ path: "order" })
+      .populate({ path: "eventRegistration" });
     return transaction;
   } catch (error) {
     logger.warn(
@@ -33,13 +36,18 @@ export async function updateTransactionStatus(
   reference,
   status,
   orderId = null,
-  paystackResponse = null
+  paystackResponse = null,
+  eventRegistrationId = null
 ) {
   try {
     const updateData = { status };
 
     if (orderId) {
       updateData.order = orderId;
+    }
+
+    if (eventRegistrationId) {
+      updateData.eventRegistration = eventRegistrationId;
     }
 
     if (paystackResponse) {
@@ -54,8 +62,9 @@ export async function updateTransactionStatus(
         runValidators: true,
       }
     )
-      .populate({ path: "user", select: "name email" })
-      .populate({ path: "order" });
+      .populate({ path: "user", select: "name email displayName isGuest" })
+      .populate({ path: "order" })
+      .populate({ path: "eventRegistration" });
 
     return updatedTransaction;
   } catch (error) {

--- a/src/models/transaction.mongo.js
+++ b/src/models/transaction.mongo.js
@@ -1,7 +1,4 @@
 import { Schema, model } from "mongoose";
-import User from "./user.mongo.js";
-import Order from "./order.mongo.js";
-import Discount from "./discount.mongo.js";
 import { OrderItemSchema } from "./schemas/orderItem.schema.js";
 import { ShippingInfoSchema } from "./schemas/shippingInfo.schema.js";
 
@@ -17,7 +14,7 @@ const TransactionSchema = new Schema(
 
     user: {
       type: Schema.Types.ObjectId,
-      ref: User,
+      ref: "User",
       required: true,
     },
 
@@ -60,7 +57,7 @@ const TransactionSchema = new Schema(
       discountAmount: { type: Number, min: 0, default: 0 },
       discountId: {
         type: Schema.Types.ObjectId,
-        ref: Discount,
+        ref: "Discount",
         default: null,
       },
     },
@@ -105,7 +102,7 @@ const TransactionSchema = new Schema(
 
     order: {
       type: Schema.Types.ObjectId,
-      ref: Order,
+      ref: "Order",
       default: null,
     },
 

--- a/src/models/transaction.mongo.js
+++ b/src/models/transaction.mongo.js
@@ -41,11 +41,18 @@ const TransactionSchema = new Schema(
       default: "pending",
     },
 
+    purpose: {
+      type: String,
+      enum: ["order", "event_ticket"],
+      default: "order",
+      index: true,
+    },
+
     // Store order data for creating order after successful payment
     orderData: {
       items: [OrderItemSchema],
       shippingInfo: ShippingInfoSchema,
-      totalPrice: { type: Number, min: 0, required: true },
+      totalPrice: { type: Number, min: 0 },
       expressService: { type: Boolean, default: false },
       expressFee: { type: Number, min: 0, default: 0 },
       // Discount details (optional) used for order creation and usage tracking
@@ -54,6 +61,38 @@ const TransactionSchema = new Schema(
       discountId: {
         type: Schema.Types.ObjectId,
         ref: Discount,
+        default: null,
+      },
+    },
+
+    eventPurchaseData: {
+      eventId: {
+        type: Schema.Types.ObjectId,
+        ref: "Event",
+        default: null,
+      },
+      ticketTypeId: {
+        type: Schema.Types.ObjectId,
+        default: null,
+      },
+      quantity: {
+        type: Number,
+        min: 1,
+        default: null,
+      },
+      ticketName: {
+        type: String,
+        trim: true,
+        default: null,
+      },
+      pricePerTicket: {
+        type: Number,
+        min: 1,
+        default: null,
+      },
+      totalPrice: {
+        type: Number,
+        min: 1,
         default: null,
       },
     },
@@ -67,6 +106,12 @@ const TransactionSchema = new Schema(
     order: {
       type: Schema.Types.ObjectId,
       ref: Order,
+      default: null,
+    },
+
+    eventRegistration: {
+      type: Schema.Types.ObjectId,
+      ref: "EventRegistration",
       default: null,
     },
   },

--- a/src/routes/admin.routes.js
+++ b/src/routes/admin.routes.js
@@ -4,6 +4,7 @@ import { authenticateToken, checkAdmin } from "../middleware/index.js";
 import {
   validateEvent,
   validateEventStatus,
+  validateEventTicketCheckout,
   validateEventTicketType,
   validateFormSchema,
   validateProduct,
@@ -43,6 +44,7 @@ import {
   getEventsAdmin,
   getVolunteerApplicationByIdAdmin,
   getVolunteerApplicationsAdmin,
+  initializeEventTicketCheckoutAdmin,
   updateEventAdmin,
   updateEventTicketTypeAdmin,
   updateEventStatusAdmin,
@@ -249,6 +251,14 @@ router.get(
   authenticateToken,
   checkAdmin,
   getEventAttendeeByIdAdmin
+);
+
+router.post(
+  "/events/:id/checkout",
+  authenticateToken,
+  checkAdmin,
+  validateEventTicketCheckout,
+  initializeEventTicketCheckoutAdmin
 );
 
 router.post(

--- a/src/services/eventCheckoutLogic.js
+++ b/src/services/eventCheckoutLogic.js
@@ -1,0 +1,48 @@
+import { hasEventCapacity } from "./eventCapacityLogic.js";
+import { isTicketPurchasable } from "./eventTicketService.js";
+
+export function calculateTicketPurchaseAmount(ticketType, quantity) {
+  return Number(ticketType.pricePesewas) * Number(quantity);
+}
+
+export function getPayerEmail(principal, guestInfo = {}) {
+  if (principal?.type === "user" && principal.user?.email) {
+    return principal.user.email;
+  }
+
+  return guestInfo.email;
+}
+
+export function buildEventPurchaseData(event, ticketType, quantity) {
+  return {
+    eventId: event._id,
+    ticketTypeId: ticketType._id,
+    quantity,
+    ticketName: ticketType.name,
+    pricePerTicket: ticketType.pricePesewas,
+    totalPrice: calculateTicketPurchaseAmount(ticketType, quantity),
+  };
+}
+
+export function assertEventTicketCheckoutAllowed(
+  event,
+  ticketType,
+  quantity,
+  confirmedCount = 0
+) {
+  if (!event) {
+    throw new Error("Event not found");
+  }
+
+  if (!ticketType) {
+    throw new Error("Ticket type not found");
+  }
+
+  if (!hasEventCapacity(event, quantity, confirmedCount)) {
+    throw new Error("Event does not have enough remaining capacity");
+  }
+
+  if (!isTicketPurchasable(ticketType, event, quantity)) {
+    throw new Error("Ticket type is not available for purchase");
+  }
+}

--- a/src/services/eventCheckoutService.js
+++ b/src/services/eventCheckoutService.js
@@ -1,0 +1,187 @@
+import { createTransaction } from "../models/transaction.model.js";
+import {
+  createEventRegistration,
+  updateEventRegistrationPayment,
+} from "../models/eventRegistration.model.js";
+import {
+  getEventById,
+  incrementEventTicketSoldCount,
+} from "../models/event.model.js";
+import {
+  generateTransactionReference,
+  initializeTransaction,
+} from "./paystackService.js";
+import { getConfirmedCount, hasEventCapacity } from "./eventCapacityService.js";
+import { isTicketPurchasable } from "./eventTicketService.js";
+
+export function calculateTicketPurchaseAmount(ticketType, quantity) {
+  return Number(ticketType.pricePesewas) * Number(quantity);
+}
+
+export function getPayerEmail(principal, guestInfo = {}) {
+  if (principal?.type === "user" && principal.user?.email) {
+    return principal.user.email;
+  }
+
+  return guestInfo.email;
+}
+
+export function buildEventPurchaseData(event, ticketType, quantity) {
+  return {
+    eventId: event._id,
+    ticketTypeId: ticketType._id,
+    quantity,
+    ticketName: ticketType.name,
+    pricePerTicket: ticketType.pricePesewas,
+    totalPrice: calculateTicketPurchaseAmount(ticketType, quantity),
+  };
+}
+
+export function assertEventTicketCheckoutAllowed(
+  event,
+  ticketType,
+  quantity,
+  confirmedCount = 0
+) {
+  if (!event) {
+    throw new Error("Event not found");
+  }
+
+  if (!ticketType) {
+    throw new Error("Ticket type not found");
+  }
+
+  if (!hasEventCapacity(event, quantity, confirmedCount)) {
+    throw new Error("Event does not have enough remaining capacity");
+  }
+
+  if (!isTicketPurchasable(ticketType, event, quantity)) {
+    throw new Error("Ticket type is not available for purchase");
+  }
+}
+
+export async function initializeEventTicketCheckout({
+  eventId,
+  principal,
+  ticketTypeId,
+  quantity,
+  guestInfo = {},
+  formResponses = {},
+  confirmedCount,
+}) {
+  const event = await getEventById(eventId);
+  if (!event) {
+    throw new Error("Event not found");
+  }
+
+  const ticketType = event.ticketTypes.id(ticketTypeId);
+  const effectiveConfirmedCount =
+    confirmedCount ?? (await getConfirmedCount(event._id));
+  assertEventTicketCheckoutAllowed(
+    event,
+    ticketType,
+    quantity,
+    effectiveConfirmedCount
+  );
+
+  const payerEmail = getPayerEmail(principal, guestInfo);
+  if (!payerEmail) {
+    throw new Error("A valid email is required to initialize payment");
+  }
+
+  const eventPurchaseData = buildEventPurchaseData(event, ticketType, quantity);
+  const registration = await createEventRegistration({
+    event: event._id,
+    user: principal?._id ?? null,
+    guestInfo,
+    formResponses,
+    ticketTypeId: ticketType._id,
+    status: "pending",
+  });
+  const reference = generateTransactionReference(principal._id.toString());
+  const transaction = await createTransaction({
+    reference,
+    user: principal._id,
+    amount: eventPurchaseData.totalPrice,
+    currency: "GHS",
+    status: "pending",
+    purpose: "event_ticket",
+    eventPurchaseData,
+    eventRegistration: registration._id,
+  });
+
+  const paystackResponse = await initializeTransaction(
+    payerEmail,
+    eventPurchaseData.totalPrice,
+    {
+      purpose: "event_ticket",
+      userId: principal._id.toString(),
+      transactionId: transaction._id.toString(),
+      eventId: event._id.toString(),
+      eventRegistrationId: registration._id.toString(),
+      ticketTypeId: ticketType._id.toString(),
+      quantity,
+    },
+    reference
+  );
+
+  transaction.paystackResponse = paystackResponse;
+  await transaction.save();
+
+  return {
+    authorizationUrl: paystackResponse.data.authorization_url,
+    reference,
+    amount: eventPurchaseData.totalPrice / 100,
+    amountPesewas: eventPurchaseData.totalPrice,
+    currency: "GHS",
+    eventRegistration: registration,
+    transaction,
+  };
+}
+
+export async function confirmEventTicketPayment(transaction) {
+  if (transaction.eventRegistration?.status === "confirmed") {
+    return transaction.eventRegistration;
+  }
+
+  const { eventPurchaseData } = transaction;
+  const event = await getEventById(eventPurchaseData.eventId);
+  if (!event) {
+    throw new Error("Event not found");
+  }
+
+  const ticketType = event.ticketTypes.id(eventPurchaseData.ticketTypeId);
+  const confirmedCount = await getConfirmedCount(event._id);
+  assertEventTicketCheckoutAllowed(
+    event,
+    ticketType,
+    eventPurchaseData.quantity,
+    confirmedCount
+  );
+
+  await incrementEventTicketSoldCount(
+    event._id,
+    ticketType._id,
+    eventPurchaseData.quantity
+  );
+
+  const eventRegistrationId =
+    transaction.eventRegistration?._id ?? transaction.eventRegistration;
+
+  return updateEventRegistrationPayment(eventRegistrationId, {
+    status: "confirmed",
+    transactionId: transaction._id,
+  });
+}
+
+export async function cancelEventTicketRegistration(transaction) {
+  if (!transaction?.eventRegistration) return null;
+
+  const eventRegistrationId =
+    transaction.eventRegistration?._id ?? transaction.eventRegistration;
+
+  return updateEventRegistrationPayment(eventRegistrationId, {
+    status: "cancelled",
+    transactionId: transaction._id,
+  });
+}

--- a/src/services/eventCheckoutService.js
+++ b/src/services/eventCheckoutService.js
@@ -11,54 +11,20 @@ import {
   generateTransactionReference,
   initializeTransaction,
 } from "./paystackService.js";
-import { getConfirmedCount, hasEventCapacity } from "./eventCapacityService.js";
-import { isTicketPurchasable } from "./eventTicketService.js";
+import { getConfirmedCount } from "./eventCapacityService.js";
+import {
+  assertEventTicketCheckoutAllowed,
+  buildEventPurchaseData,
+  calculateTicketPurchaseAmount,
+  getPayerEmail,
+} from "./eventCheckoutLogic.js";
 
-export function calculateTicketPurchaseAmount(ticketType, quantity) {
-  return Number(ticketType.pricePesewas) * Number(quantity);
-}
-
-export function getPayerEmail(principal, guestInfo = {}) {
-  if (principal?.type === "user" && principal.user?.email) {
-    return principal.user.email;
-  }
-
-  return guestInfo.email;
-}
-
-export function buildEventPurchaseData(event, ticketType, quantity) {
-  return {
-    eventId: event._id,
-    ticketTypeId: ticketType._id,
-    quantity,
-    ticketName: ticketType.name,
-    pricePerTicket: ticketType.pricePesewas,
-    totalPrice: calculateTicketPurchaseAmount(ticketType, quantity),
-  };
-}
-
-export function assertEventTicketCheckoutAllowed(
-  event,
-  ticketType,
-  quantity,
-  confirmedCount = 0
-) {
-  if (!event) {
-    throw new Error("Event not found");
-  }
-
-  if (!ticketType) {
-    throw new Error("Ticket type not found");
-  }
-
-  if (!hasEventCapacity(event, quantity, confirmedCount)) {
-    throw new Error("Event does not have enough remaining capacity");
-  }
-
-  if (!isTicketPurchasable(ticketType, event, quantity)) {
-    throw new Error("Ticket type is not available for purchase");
-  }
-}
+export {
+  assertEventTicketCheckoutAllowed,
+  buildEventPurchaseData,
+  calculateTicketPurchaseAmount,
+  getPayerEmail,
+};
 
 export async function initializeEventTicketCheckout({
   eventId,

--- a/src/validators/eventCheckout.validator.js
+++ b/src/validators/eventCheckout.validator.js
@@ -1,0 +1,25 @@
+import Joi from "joi";
+import mongoose from "mongoose";
+
+const objectIdValidator = (value, helpers) => {
+  if (!mongoose.Types.ObjectId.isValid(value)) {
+    return helpers.error("any.invalid");
+  }
+  return value;
+};
+
+export const eventTicketCheckoutValidator = Joi.object({
+  ticketTypeId: Joi.string()
+    .custom(objectIdValidator, "ObjectId Validation")
+    .required(),
+  quantity: Joi.number().integer().min(1).required(),
+  guestInfo: Joi.object({
+    name: Joi.string().trim().allow("").optional(),
+    email: Joi.string().email().trim().allow("").optional(),
+    phone: Joi.string().trim().allow("").optional(),
+  }).default({}),
+  formResponses: Joi.object({
+    builtinFields: Joi.object().unknown(true).default({}),
+    customAnswers: Joi.object().unknown(true).default({}),
+  }).default({ builtinFields: {}, customAnswers: {} }),
+});

--- a/tests/public/events/eventCheckoutService.test.js
+++ b/tests/public/events/eventCheckoutService.test.js
@@ -1,0 +1,70 @@
+/*eslint-disable no-undef */
+import {
+  assertEventTicketCheckoutAllowed,
+  buildEventPurchaseData,
+  calculateTicketPurchaseAmount,
+  getPayerEmail,
+} from "../../../src/services/eventCheckoutService.js";
+
+describe("eventCheckoutService", () => {
+  const event = {
+    _id: "64a000000000000000000010",
+    type: "paid",
+    status: "published",
+    maxAttendees: 10,
+  };
+  const ticketType = {
+    _id: "64a000000000000000000001",
+    name: "Early Bird",
+    pricePesewas: 5000,
+    maxQuantity: 5,
+    soldCount: 2,
+    expiresAt: "2026-08-02T18:00:00.000Z",
+    isActive: true,
+  };
+
+  it("calculates ticket purchase totals in pesewas", () => {
+    expect(calculateTicketPurchaseAmount(ticketType, 3)).toBe(15000);
+  });
+
+  it("builds a transaction snapshot for event ticket purchases", () => {
+    expect(buildEventPurchaseData(event, ticketType, 2)).toEqual({
+      eventId: event._id,
+      ticketTypeId: ticketType._id,
+      quantity: 2,
+      ticketName: "Early Bird",
+      pricePerTicket: 5000,
+      totalPrice: 10000,
+    });
+  });
+
+  it("prefers authenticated user email and falls back to guest email", () => {
+    expect(
+      getPayerEmail({
+        type: "user",
+        user: { email: "owner@example.com" },
+      })
+    ).toBe("owner@example.com");
+    expect(getPayerEmail({ type: "guest" }, { email: "guest@example.com" })).toBe(
+      "guest@example.com"
+    );
+  });
+
+  it("allows checkout when event and ticket capacities are available", () => {
+    expect(() =>
+      assertEventTicketCheckoutAllowed(event, ticketType, 2, 8)
+    ).not.toThrow();
+  });
+
+  it("rejects checkout when event capacity is exceeded", () => {
+    expect(() =>
+      assertEventTicketCheckoutAllowed(event, ticketType, 2, 9)
+    ).toThrow("Event does not have enough remaining capacity");
+  });
+
+  it("rejects checkout when ticket capacity is exceeded", () => {
+    expect(() =>
+      assertEventTicketCheckoutAllowed(event, ticketType, 4, 1)
+    ).toThrow("Ticket type is not available for purchase");
+  });
+});

--- a/tests/public/events/eventCheckoutService.test.js
+++ b/tests/public/events/eventCheckoutService.test.js
@@ -4,9 +4,9 @@ import {
   buildEventPurchaseData,
   calculateTicketPurchaseAmount,
   getPayerEmail,
-} from "../../../src/services/eventCheckoutService.js";
+} from "../../../src/services/eventCheckoutLogic.js";
 
-describe("eventCheckoutService", () => {
+describe("eventCheckoutLogic", () => {
   const event = {
     _id: "64a000000000000000000010",
     type: "paid",

--- a/tests/public/events/eventTransactionModel.test.js
+++ b/tests/public/events/eventTransactionModel.test.js
@@ -1,0 +1,49 @@
+/*eslint-disable no-undef */
+import { Types } from "mongoose";
+import Transaction from "../../../src/models/transaction.mongo.js";
+
+describe("Transaction event ticket fields", () => {
+  it("validates event ticket transactions without order data", () => {
+    const transaction = new Transaction({
+      reference: "MISQ_EVENT_123",
+      user: new Types.ObjectId(),
+      amount: 10000,
+      currency: "GHS",
+      status: "pending",
+      purpose: "event_ticket",
+      eventPurchaseData: {
+        eventId: new Types.ObjectId(),
+        ticketTypeId: new Types.ObjectId(),
+        quantity: 2,
+        ticketName: "Early Bird",
+        pricePerTicket: 5000,
+        totalPrice: 10000,
+      },
+      eventRegistration: new Types.ObjectId(),
+    });
+
+    expect(transaction.validateSync()).toBeUndefined();
+  });
+
+  it("defaults purpose to order for existing checkout transactions", () => {
+    const transaction = new Transaction({
+      reference: "MISQ_ORDER_123",
+      user: new Types.ObjectId(),
+      amount: 10000,
+      currency: "GHS",
+      status: "pending",
+      orderData: {
+        items: [],
+        shippingInfo: {
+          fullName: "Ama",
+          email: "ama@example.com",
+          phone: "0240000000",
+          deliveryAddress: "Accra",
+        },
+        totalPrice: 100,
+      },
+    });
+
+    expect(transaction.purpose).toBe("order");
+  });
+});


### PR DESCRIPTION
## Description
This branch extends the existing Paystack transaction flow to support paid event tickets while preserving the current order checkout behavior. It adds event-ticket transaction metadata, pending attendee registration creation, Paystack checkout initialization, and webhook/manual verification handling that confirms registrations and increments ticket sales. The branch also adds an admin test checkout route before the public event checkout API is introduced later.

## Key changes
- Add `purpose: "order" | "event_ticket"` to `Transaction`, defaulting existing transactions to `order`.
- Add `eventPurchaseData` and `eventRegistration` fields to `Transaction`.
- Add event checkout service helpers for amount calculation, event purchase snapshots, payer email selection, capacity checks, Paystack initialization, and event-ticket confirmation.
- Add admin `POST /admin/events/:id/checkout` route for initiating event ticket checkout.
- Add checkout request validation for ticket type, quantity, guest info, and form responses.
- Update Paystack success handling to branch event-ticket transactions into registration confirmation and ticket `soldCount` incrementing.
- Update failed payment handling to cancel pending event-ticket registrations.
- Include `eventRegistration` in payment verification responses.
- Add unit tests for event checkout behavior and event-ticket transaction schema validation.
