### PR TITLE
Add public event listing, RSVP, checkout, and volunteer application routes

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -18,6 +18,7 @@ import discountRoutes from "./routes/discount.routes.js";
 import favoritesRoutes from "./routes/favorites.routes.js";
 import orderRoutes from "./routes/orders.routes.js";
 import paymentRoutes from "./routes/payment.routes.js";
+import eventsRoutes from "./routes/events.routes.js";
 import productRoutes from "./routes/products.routes.js";
 import newsletterRoutes from "./routes/newsletter.routes.js";
 import contactRoutes from "./routes/contact.routes.js";
@@ -63,6 +64,7 @@ app.use(`${API_PREFIX}/favorites`, rateLimiters.general, favoritesRoutes);
 app.use(`${API_PREFIX}/orders`, routeLimiters.order, orderRoutes);
 
 app.use(`${API_PREFIX}/payment`, paymentRoutes);
+app.use(`${API_PREFIX}/events`, routeLimiters.events, eventsRoutes);
 app.use(`${API_PREFIX}/products`, routeLimiters.products, productRoutes);
 app.use(`${API_PREFIX}/newsletter`, routeLimiters.newsletter, newsletterRoutes);
 app.use(`${API_PREFIX}/contact`, routeLimiters.contact, contactRoutes);

--- a/src/config/rateLimiter.js
+++ b/src/config/rateLimiter.js
@@ -70,5 +70,6 @@ export const routeLimiters = {
   contact: rateLimiters.strict, // 10 requests
   bespoke: rateLimiters.strict, // 10 requests
   admin: rateLimiters.lenient, // 200 requests
+  events: rateLimiters.general, // 100 requests
   products: rateLimiters.productSlowDown,
 };

--- a/src/controllers/events.public.controller.js
+++ b/src/controllers/events.public.controller.js
@@ -10,6 +10,7 @@ import {
   toPublicEventDetail,
   toPublicEventListItem,
 } from "../services/eventPublicService.js";
+import { registerForFreeEvent } from "../services/eventRegistrationService.js";
 import { formatResponse } from "../utils/responseFormatter.js";
 
 const PUBLISHED_EVENT_FILTER = "published";
@@ -88,6 +89,43 @@ export async function getPublishedEventById(req, res) {
       formatResponse({
         success: false,
         error: "Failed to load event",
+      })
+    );
+  }
+}
+
+export async function registerForFreeEventPublic(req, res) {
+  try {
+    const registration = await registerForFreeEvent({
+      eventId: req.params.id,
+      principal: req.principal,
+      guestInfo: req.body.guestInfo,
+      formResponses: req.body.formResponses,
+    });
+
+    res.status(201).json(
+      formatResponse({
+        message: "Event registration confirmed successfully",
+        data: registration,
+      })
+    );
+  } catch (error) {
+    if (error.message === "Event not found") {
+      return res.status(404).json(
+        formatResponse({
+          success: false,
+          error: "Event not found",
+        })
+      );
+    }
+
+    logger.error(
+      `[events.public.controller] Error registering for event ${req.params.id}: ${error.message}`
+    );
+    res.status(400).json(
+      formatResponse({
+        success: false,
+        error: error.message,
       })
     );
   }

--- a/src/controllers/events.public.controller.js
+++ b/src/controllers/events.public.controller.js
@@ -1,0 +1,94 @@
+import {
+  countEvents,
+  getEventById,
+  getPaginatedEvents,
+} from "../models/event.model.js";
+import logger from "../config/logger.js";
+import { getConfirmedCount } from "../services/eventCapacityService.js";
+import {
+  assertEventIsPublic,
+  toPublicEventDetail,
+  toPublicEventListItem,
+} from "../services/eventPublicService.js";
+import { formatResponse } from "../utils/responseFormatter.js";
+
+const PUBLISHED_EVENT_FILTER = "published";
+
+export async function getPublishedEvents(req, res) {
+  try {
+    const { page, limit, type, q } = req.query;
+    const pageNum = Math.max(parseInt(page) || 1, 1);
+    const limitNum = Math.max(parseInt(limit) || 10, 1);
+    const filters = {
+      status: PUBLISHED_EVENT_FILTER,
+      type: type?.trim() || undefined,
+      q: q?.trim() || undefined,
+    };
+
+    const total = await countEvents(filters);
+
+    if (pageNum > Math.ceil(total / limitNum) && total > 0) {
+      return res.status(400).json(
+        formatResponse({
+          success: false,
+          error: "Requested page exceeds available event pages",
+        })
+      );
+    }
+
+    const events = await getPaginatedEvents(pageNum, limitNum, filters);
+
+    res.status(200).json(
+      formatResponse({
+        data: events.map(toPublicEventListItem),
+        total,
+        totalPages: Math.ceil(total / limitNum),
+        currentPage: pageNum,
+      })
+    );
+  } catch (error) {
+    logger.error(
+      `[events.public.controller] Error listing public events: ${error.message}`
+    );
+    res.status(500).json(
+      formatResponse({
+        success: false,
+        error: "Failed to load events",
+      })
+    );
+  }
+}
+
+export async function getPublishedEventById(req, res) {
+  try {
+    const event = await getEventById(req.params.id);
+    assertEventIsPublic(event);
+
+    const confirmedCount = await getConfirmedCount(event._id);
+
+    res.status(200).json(
+      formatResponse({
+        data: toPublicEventDetail(event, confirmedCount),
+      })
+    );
+  } catch (error) {
+    if (error.message === "Event not found") {
+      return res.status(404).json(
+        formatResponse({
+          success: false,
+          error: "Event not found",
+        })
+      );
+    }
+
+    logger.error(
+      `[events.public.controller] Error loading public event ${req.params.id}: ${error.message}`
+    );
+    res.status(500).json(
+      formatResponse({
+        success: false,
+        error: "Failed to load event",
+      })
+    );
+  }
+}

--- a/src/controllers/events.public.controller.js
+++ b/src/controllers/events.public.controller.js
@@ -12,6 +12,7 @@ import {
 } from "../services/eventPublicService.js";
 import { initializeEventTicketCheckout } from "../services/eventCheckoutService.js";
 import { registerForFreeEvent } from "../services/eventRegistrationService.js";
+import { submitVolunteerApplication } from "../services/volunteerApplicationService.js";
 import { formatResponse } from "../utils/responseFormatter.js";
 
 const PUBLISHED_EVENT_FILTER = "published";
@@ -161,6 +162,42 @@ export async function initializeEventTicketCheckoutPublic(req, res) {
 
     logger.error(
       `[events.public.controller] Error initializing checkout for event ${req.params.id}: ${error.message}`
+    );
+    res.status(400).json(
+      formatResponse({
+        success: false,
+        error: error.message,
+      })
+    );
+  }
+}
+
+export async function submitVolunteerApplicationPublic(req, res) {
+  try {
+    const application = await submitVolunteerApplication({
+      eventId: req.params.id,
+      applicantInfo: req.body.applicantInfo,
+      formResponses: req.body.formResponses,
+    });
+
+    res.status(201).json(
+      formatResponse({
+        message: "Volunteer application submitted successfully",
+        data: application,
+      })
+    );
+  } catch (error) {
+    if (error.message === "Event not found") {
+      return res.status(404).json(
+        formatResponse({
+          success: false,
+          error: "Event not found",
+        })
+      );
+    }
+
+    logger.error(
+      `[events.public.controller] Error submitting volunteer application for event ${req.params.id}: ${error.message}`
     );
     res.status(400).json(
       formatResponse({

--- a/src/controllers/events.public.controller.js
+++ b/src/controllers/events.public.controller.js
@@ -10,6 +10,7 @@ import {
   toPublicEventDetail,
   toPublicEventListItem,
 } from "../services/eventPublicService.js";
+import { initializeEventTicketCheckout } from "../services/eventCheckoutService.js";
 import { registerForFreeEvent } from "../services/eventRegistrationService.js";
 import { formatResponse } from "../utils/responseFormatter.js";
 
@@ -121,6 +122,45 @@ export async function registerForFreeEventPublic(req, res) {
 
     logger.error(
       `[events.public.controller] Error registering for event ${req.params.id}: ${error.message}`
+    );
+    res.status(400).json(
+      formatResponse({
+        success: false,
+        error: error.message,
+      })
+    );
+  }
+}
+
+export async function initializeEventTicketCheckoutPublic(req, res) {
+  try {
+    const checkout = await initializeEventTicketCheckout({
+      eventId: req.params.id,
+      principal: req.principal,
+      ticketTypeId: req.body.ticketTypeId,
+      quantity: req.body.quantity,
+      guestInfo: req.body.guestInfo,
+      formResponses: req.body.formResponses,
+    });
+
+    res.status(200).json(
+      formatResponse({
+        message: "Event ticket payment initialized successfully",
+        data: checkout,
+      })
+    );
+  } catch (error) {
+    if (error.message === "Event not found") {
+      return res.status(404).json(
+        formatResponse({
+          success: false,
+          error: "Event not found",
+        })
+      );
+    }
+
+    logger.error(
+      `[events.public.controller] Error initializing checkout for event ${req.params.id}: ${error.message}`
     );
     res.status(400).json(
       formatResponse({

--- a/src/middleware/validator.middleware.js
+++ b/src/middleware/validator.middleware.js
@@ -14,6 +14,7 @@ import {
 import { eventTicketCheckoutValidator } from "../validators/eventCheckout.validator.js";
 import { eventRegistrationValidator } from "../validators/eventRegistration.validator.js";
 import { volunteerApplicationStatusValidator } from "../validators/volunteerApplication.validator.js";
+import { volunteerApplicationSubmitValidator } from "../validators/volunteerApplicationSubmit.validator.js";
 import { formatResponse } from "../utils/responseFormatter.js";
 
 export function validateUser(req, res, next) {
@@ -231,6 +232,27 @@ export function validateEventRegistration(req, res, next) {
   const { error, value } = eventRegistrationValidator.validate(req.body, {
     abortEarly: false,
   });
+
+  if (error) {
+    return res.status(400).json(
+      formatResponse({
+        success: false,
+        errors: error.details.map(err => err.message),
+      })
+    );
+  }
+
+  req.body = value;
+  next();
+}
+
+export function validateVolunteerApplicationSubmit(req, res, next) {
+  const { error, value } = volunteerApplicationSubmitValidator.validate(
+    req.body,
+    {
+      abortEarly: false,
+    }
+  );
 
   if (error) {
     return res.status(400).json(

--- a/src/middleware/validator.middleware.js
+++ b/src/middleware/validator.middleware.js
@@ -12,6 +12,7 @@ import {
   eventValidator,
 } from "../validators/event.validator.js";
 import { eventTicketCheckoutValidator } from "../validators/eventCheckout.validator.js";
+import { eventRegistrationValidator } from "../validators/eventRegistration.validator.js";
 import { volunteerApplicationStatusValidator } from "../validators/volunteerApplication.validator.js";
 import { formatResponse } from "../utils/responseFormatter.js";
 
@@ -210,6 +211,24 @@ export function validateVolunteerApplicationStatus(req, res, next) {
 
 export function validateEventTicketCheckout(req, res, next) {
   const { error, value } = eventTicketCheckoutValidator.validate(req.body, {
+    abortEarly: false,
+  });
+
+  if (error) {
+    return res.status(400).json(
+      formatResponse({
+        success: false,
+        errors: error.details.map(err => err.message),
+      })
+    );
+  }
+
+  req.body = value;
+  next();
+}
+
+export function validateEventRegistration(req, res, next) {
+  const { error, value } = eventRegistrationValidator.validate(req.body, {
     abortEarly: false,
   });
 

--- a/src/models/eventRegistration.model.js
+++ b/src/models/eventRegistration.model.js
@@ -2,6 +2,16 @@ import { Types } from "mongoose";
 import logger from "../config/logger.js";
 import EventRegistration from "./eventRegistration.mongo.js";
 
+const ACTIVE_REGISTRATION_STATUSES = ["pending", "confirmed"];
+
+function normalizeEmail(email) {
+  return typeof email === "string" ? email.trim().toLowerCase() : "";
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 export async function createEventRegistration(registrationData) {
   try {
     return await EventRegistration.create(registrationData);
@@ -79,6 +89,33 @@ export async function countConfirmedRegistrations(eventId, params = {}) {
     ...params,
     status: "confirmed",
   });
+}
+
+export async function findActiveRegistrationByEventAndEmail(eventId, email) {
+  try {
+    if (!Types.ObjectId.isValid(eventId)) {
+      return null;
+    }
+
+    const normalizedEmail = normalizeEmail(email);
+    if (!normalizedEmail) {
+      return null;
+    }
+
+    return await EventRegistration.findOne({
+      event: eventId,
+      status: { $in: ACTIVE_REGISTRATION_STATUSES },
+      "guestInfo.email": {
+        $regex: `^${escapeRegExp(normalizedEmail)}$`,
+        $options: "i",
+      },
+    });
+  } catch (error) {
+    logger.error(
+      `[eventRegistration.model] Error finding active registration for event ${eventId} and email ${email}: ${error.message}`
+    );
+    throw error;
+  }
 }
 
 export async function getEventRegistrationById(eventId, registrationId) {

--- a/src/models/volunteerApplication.model.js
+++ b/src/models/volunteerApplication.model.js
@@ -2,6 +2,16 @@ import { Types } from "mongoose";
 import logger from "../config/logger.js";
 import VolunteerApplication from "./volunteerApplication.mongo.js";
 
+const ACTIVE_VOLUNTEER_APPLICATION_STATUSES = ["pending", "accepted"];
+
+function normalizeEmail(email) {
+  return typeof email === "string" ? email.trim().toLowerCase() : "";
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 export async function createVolunteerApplication(applicationData) {
   try {
     return await VolunteerApplication.create(applicationData);
@@ -59,6 +69,36 @@ export async function countVolunteerApplications(eventId, params = {}) {
   } catch (error) {
     logger.error(
       `[volunteerApplication.model] Error counting volunteer applications for event ${eventId}: ${error.message}`
+    );
+    throw error;
+  }
+}
+
+export async function findActiveVolunteerApplicationByEventAndEmail(
+  eventId,
+  email
+) {
+  try {
+    if (!Types.ObjectId.isValid(eventId)) {
+      return null;
+    }
+
+    const normalizedEmail = normalizeEmail(email);
+    if (!normalizedEmail) {
+      return null;
+    }
+
+    return await VolunteerApplication.findOne({
+      event: eventId,
+      status: { $in: ACTIVE_VOLUNTEER_APPLICATION_STATUSES },
+      "applicantInfo.email": {
+        $regex: `^${escapeRegExp(normalizedEmail)}$`,
+        $options: "i",
+      },
+    });
+  } catch (error) {
+    logger.error(
+      `[volunteerApplication.model] Error finding active volunteer application for event ${eventId} and email ${email}: ${error.message}`
     );
     throw error;
   }

--- a/src/routes/events.routes.js
+++ b/src/routes/events.routes.js
@@ -1,0 +1,12 @@
+import express from "express";
+import {
+  getPublishedEventById,
+  getPublishedEvents,
+} from "../controllers/events.public.controller.js";
+
+const router = express.Router();
+
+router.get("/", getPublishedEvents);
+router.get("/:id", getPublishedEventById);
+
+export default router;

--- a/src/routes/events.routes.js
+++ b/src/routes/events.routes.js
@@ -1,12 +1,23 @@
 import express from "express";
+import { rateLimiters } from "../config/rateLimiter.js";
 import {
   getPublishedEventById,
   getPublishedEvents,
+  registerForFreeEventPublic,
 } from "../controllers/events.public.controller.js";
+import { authenticateOptionalPrincipal } from "../middleware/index.js";
+import { validateEventRegistration } from "../middleware/validator.middleware.js";
 
 const router = express.Router();
 
 router.get("/", getPublishedEvents);
+router.post(
+  "/:id/register",
+  rateLimiters.strict,
+  validateEventRegistration,
+  authenticateOptionalPrincipal,
+  registerForFreeEventPublic
+);
 router.get("/:id", getPublishedEventById);
 
 export default router;

--- a/src/routes/events.routes.js
+++ b/src/routes/events.routes.js
@@ -3,10 +3,14 @@ import { rateLimiters } from "../config/rateLimiter.js";
 import {
   getPublishedEventById,
   getPublishedEvents,
+  initializeEventTicketCheckoutPublic,
   registerForFreeEventPublic,
 } from "../controllers/events.public.controller.js";
 import { authenticateOptionalPrincipal } from "../middleware/index.js";
-import { validateEventRegistration } from "../middleware/validator.middleware.js";
+import {
+  validateEventRegistration,
+  validateEventTicketCheckout,
+} from "../middleware/validator.middleware.js";
 
 const router = express.Router();
 
@@ -17,6 +21,13 @@ router.post(
   validateEventRegistration,
   authenticateOptionalPrincipal,
   registerForFreeEventPublic
+);
+router.post(
+  "/:id/checkout",
+  rateLimiters.strict,
+  validateEventTicketCheckout,
+  authenticateOptionalPrincipal,
+  initializeEventTicketCheckoutPublic
 );
 router.get("/:id", getPublishedEventById);
 

--- a/src/routes/events.routes.js
+++ b/src/routes/events.routes.js
@@ -5,11 +5,13 @@ import {
   getPublishedEvents,
   initializeEventTicketCheckoutPublic,
   registerForFreeEventPublic,
+  submitVolunteerApplicationPublic,
 } from "../controllers/events.public.controller.js";
 import { authenticateOptionalPrincipal } from "../middleware/index.js";
 import {
   validateEventRegistration,
   validateEventTicketCheckout,
+  validateVolunteerApplicationSubmit,
 } from "../middleware/validator.middleware.js";
 
 const router = express.Router();
@@ -28,6 +30,13 @@ router.post(
   validateEventTicketCheckout,
   authenticateOptionalPrincipal,
   initializeEventTicketCheckoutPublic
+);
+router.post(
+  "/:id/volunteer-applications",
+  rateLimiters.strict,
+  validateVolunteerApplicationSubmit,
+  authenticateOptionalPrincipal,
+  submitVolunteerApplicationPublic
 );
 router.get("/:id", getPublishedEventById);
 

--- a/src/services/eventCapacityLogic.js
+++ b/src/services/eventCapacityLogic.js
@@ -6,6 +6,10 @@ export function assertEventAcceptsRegistrations(event) {
   if (event.status === "cancelled") {
     throw new Error("Cancelled events do not accept registrations");
   }
+
+  if (event.status !== "published") {
+    throw new Error("Only published events accept registrations");
+  }
 }
 
 export function hasEventCapacity(

--- a/src/services/eventCheckoutService.js
+++ b/src/services/eventCheckoutService.js
@@ -1,6 +1,7 @@
 import { createTransaction } from "../models/transaction.model.js";
 import {
   createEventRegistration,
+  findActiveRegistrationByEventAndEmail,
   updateEventRegistrationPayment,
 } from "../models/eventRegistration.model.js";
 import {
@@ -12,6 +13,12 @@ import {
   initializeTransaction,
 } from "./paystackService.js";
 import { getConfirmedCount } from "./eventCapacityService.js";
+import { assertEventIsPublic } from "./eventPublicService.js";
+import {
+  assertNoDuplicateRegistration,
+  resolveRegistrationEmail,
+} from "./eventRegistrationService.js";
+import { validateFormResponses } from "./formValidationService.js";
 import {
   assertEventTicketCheckoutAllowed,
   buildEventPurchaseData,
@@ -36,8 +43,26 @@ export async function initializeEventTicketCheckout({
   confirmedCount,
 }) {
   const event = await getEventById(eventId);
-  if (!event) {
-    throw new Error("Event not found");
+  assertEventIsPublic(event);
+
+  const registrationEmail = resolveRegistrationEmail(principal, guestInfo);
+  const existingRegistration = await findActiveRegistrationByEventAndEmail(
+    event._id,
+    registrationEmail
+  );
+  assertNoDuplicateRegistration(existingRegistration);
+
+  let normalizedResponses = { builtinFields: {}, customAnswers: {} };
+  if (event.registrationFormId) {
+    const validation = validateFormResponses(
+      event.registrationFormId,
+      formResponses
+    );
+    if (!validation.valid) {
+      throw new Error(validation.errors.join("; "));
+    }
+
+    normalizedResponses = validation.normalizedResponses;
   }
 
   const ticketType = event.ticketTypes.id(ticketTypeId);
@@ -50,7 +75,10 @@ export async function initializeEventTicketCheckout({
     effectiveConfirmedCount
   );
 
-  const payerEmail = getPayerEmail(principal, guestInfo);
+  const payerEmail = getPayerEmail(principal, {
+    ...guestInfo,
+    email: registrationEmail,
+  });
   if (!payerEmail) {
     throw new Error("A valid email is required to initialize payment");
   }
@@ -59,8 +87,11 @@ export async function initializeEventTicketCheckout({
   const registration = await createEventRegistration({
     event: event._id,
     user: principal?._id ?? null,
-    guestInfo,
-    formResponses,
+    guestInfo: {
+      ...guestInfo,
+      email: registrationEmail,
+    },
+    formResponses: normalizedResponses,
     ticketTypeId: ticketType._id,
     status: "pending",
   });

--- a/src/services/eventPublicLogic.js
+++ b/src/services/eventPublicLogic.js
@@ -1,0 +1,87 @@
+export function assertEventIsPublic(event) {
+  if (!event || event.status !== "published") {
+    throw new Error("Event not found");
+  }
+}
+
+function toPlainObject(value) {
+  if (!value) return null;
+
+  return typeof value.toObject === "function" ? value.toObject() : value;
+}
+
+function getId(value) {
+  return value?._id ?? value?.id;
+}
+
+function getRemainingQuantity(ticketType) {
+  return Math.max(
+    Number(ticketType.maxQuantity ?? 0) - Number(ticketType.soldCount ?? 0),
+    0
+  );
+}
+
+export function toPublicFormSchema(formSchema) {
+  const schema = toPlainObject(formSchema);
+  if (!schema) return null;
+
+  return {
+    _id: getId(schema),
+    builtinFields: schema.builtinFields ?? [],
+    customQuestions: schema.customQuestions ?? [],
+  };
+}
+
+export function toPublicTicketType(ticketType) {
+  const ticket = toPlainObject(ticketType);
+  if (!ticket) return null;
+
+  return {
+    _id: getId(ticket),
+    name: ticket.name,
+    pricePesewas: ticket.pricePesewas,
+    expiresAt: ticket.expiresAt,
+    isActive: ticket.isActive,
+    remainingQuantity: getRemainingQuantity(ticket),
+  };
+}
+
+export function toPublicEventListItem(event) {
+  const publicEvent = toPlainObject(event);
+  if (!publicEvent) return null;
+
+  return {
+    _id: getId(publicEvent),
+    name: publicEvent.name,
+    description: publicEvent.description,
+    eventDate: publicEvent.eventDate,
+    type: publicEvent.type,
+    status: publicEvent.status,
+    maxAttendees: publicEvent.maxAttendees,
+    venue: publicEvent.venue,
+    banner: publicEvent.banner,
+    createdAt: publicEvent.createdAt,
+    updatedAt: publicEvent.updatedAt,
+  };
+}
+
+export function toPublicEventDetail(event, confirmedCount = 0) {
+  const publicEvent = toPlainObject(event);
+  if (!publicEvent) return null;
+
+  const listItem = toPublicEventListItem(publicEvent);
+  const spotsRemaining = Math.max(
+    Number(publicEvent.maxAttendees ?? 0) - Number(confirmedCount ?? 0),
+    0
+  );
+
+  return {
+    ...listItem,
+    registrationForm: toPublicFormSchema(publicEvent.registrationFormId),
+    volunteerForm: toPublicFormSchema(publicEvent.volunteerFormId),
+    ticketTypes: (publicEvent.ticketTypes ?? [])
+      .map(toPublicTicketType)
+      .filter(Boolean),
+    spotsRemaining,
+  };
+}

--- a/src/services/eventPublicService.js
+++ b/src/services/eventPublicService.js
@@ -1,0 +1,7 @@
+export {
+  assertEventIsPublic,
+  toPublicEventDetail,
+  toPublicEventListItem,
+  toPublicFormSchema,
+  toPublicTicketType,
+} from "./eventPublicLogic.js";

--- a/src/services/eventRegistrationLogic.js
+++ b/src/services/eventRegistrationLogic.js
@@ -1,0 +1,35 @@
+import { assertEventAcceptsRegistrations } from "./eventCapacityLogic.js";
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export function normalizeEmail(email) {
+  return typeof email === "string" ? email.trim().toLowerCase() : "";
+}
+
+export function resolveRegistrationEmail(principal, guestInfo = {}) {
+  const email =
+    principal?.type === "user" && principal.user?.email
+      ? principal.user.email
+      : guestInfo.email;
+  const normalizedEmail = normalizeEmail(email);
+
+  if (!EMAIL_REGEX.test(normalizedEmail)) {
+    throw new Error("A valid email is required to register for an event");
+  }
+
+  return normalizedEmail;
+}
+
+export function assertNoDuplicateRegistration(existingRegistration) {
+  if (existingRegistration) {
+    throw new Error("This email is already registered for the event");
+  }
+}
+
+export function assertFreeEventRegistration(event) {
+  assertEventAcceptsRegistrations(event);
+
+  if (event.type !== "free") {
+    throw new Error("Free RSVP is only available for free events");
+  }
+}

--- a/src/services/eventRegistrationService.js
+++ b/src/services/eventRegistrationService.js
@@ -1,0 +1,6 @@
+export {
+  assertFreeEventRegistration,
+  assertNoDuplicateRegistration,
+  normalizeEmail,
+  resolveRegistrationEmail,
+} from "./eventRegistrationLogic.js";

--- a/src/services/eventRegistrationService.js
+++ b/src/services/eventRegistrationService.js
@@ -1,6 +1,72 @@
+import {
+  createEventRegistration,
+  findActiveRegistrationByEventAndEmail,
+} from "../models/eventRegistration.model.js";
+import { getEventById } from "../models/event.model.js";
+import { hasCapacity } from "./eventCapacityService.js";
+import { validateFormResponses } from "./formValidationService.js";
+import { assertEventIsPublic } from "./eventPublicService.js";
+import {
+  assertFreeEventRegistration,
+  assertNoDuplicateRegistration,
+  resolveRegistrationEmail,
+} from "./eventRegistrationLogic.js";
+
 export {
   assertFreeEventRegistration,
   assertNoDuplicateRegistration,
   normalizeEmail,
   resolveRegistrationEmail,
 } from "./eventRegistrationLogic.js";
+
+const EMPTY_FORM_RESPONSES = {
+  builtinFields: {},
+  customAnswers: {},
+};
+
+export async function registerForFreeEvent({
+  eventId,
+  principal,
+  guestInfo = {},
+  formResponses = EMPTY_FORM_RESPONSES,
+}) {
+  const event = await getEventById(eventId);
+  assertEventIsPublic(event);
+  assertFreeEventRegistration(event);
+
+  const registrationEmail = resolveRegistrationEmail(principal, guestInfo);
+  const existingRegistration = await findActiveRegistrationByEventAndEmail(
+    event._id,
+    registrationEmail
+  );
+  assertNoDuplicateRegistration(existingRegistration);
+
+  let normalizedResponses = EMPTY_FORM_RESPONSES;
+  if (event.registrationFormId) {
+    const validation = validateFormResponses(
+      event.registrationFormId,
+      formResponses
+    );
+    if (!validation.valid) {
+      throw new Error(validation.errors.join("; "));
+    }
+
+    normalizedResponses = validation.normalizedResponses;
+  }
+
+  const hasRemainingCapacity = await hasCapacity(event, 1);
+  if (!hasRemainingCapacity) {
+    throw new Error("Event does not have enough remaining capacity");
+  }
+
+  return createEventRegistration({
+    event: event._id,
+    user: principal?._id ?? null,
+    guestInfo: {
+      ...guestInfo,
+      email: registrationEmail,
+    },
+    formResponses: normalizedResponses,
+    status: "confirmed",
+  });
+}

--- a/src/services/volunteerApplicationService.js
+++ b/src/services/volunteerApplicationService.js
@@ -1,6 +1,64 @@
+import { getEventById } from "../models/event.model.js";
+import {
+  createVolunteerApplication,
+  findActiveVolunteerApplicationByEventAndEmail,
+} from "../models/volunteerApplication.model.js";
+import { validateFormResponses } from "./formValidationService.js";
+import {
+  assertNoDuplicateVolunteerApplication,
+  assertVolunteerApplicationAllowed,
+  resolveApplicantEmail,
+} from "./volunteerApplicationSubmitLogic.js";
+
 export {
   VOLUNTEER_APPLICATION_STATUSES,
   VOLUNTEER_APPLICATION_STATUS_TRANSITIONS,
   assertVolunteerApplicationStatusTransition,
   canTransitionVolunteerApplicationStatus,
 } from "./volunteerApplicationLogic.js";
+
+export {
+  assertNoDuplicateVolunteerApplication,
+  assertVolunteerApplicationAllowed,
+  resolveApplicantEmail,
+} from "./volunteerApplicationSubmitLogic.js";
+
+const EMPTY_FORM_RESPONSES = {
+  builtinFields: {},
+  customAnswers: {},
+};
+
+export async function submitVolunteerApplication({
+  eventId,
+  applicantInfo = {},
+  formResponses = EMPTY_FORM_RESPONSES,
+}) {
+  const event = await getEventById(eventId);
+  assertVolunteerApplicationAllowed(event);
+
+  const applicantEmail = resolveApplicantEmail(applicantInfo);
+  const existingApplication =
+    await findActiveVolunteerApplicationByEventAndEmail(
+      event._id,
+      applicantEmail
+    );
+  assertNoDuplicateVolunteerApplication(existingApplication);
+
+  const validation = validateFormResponses(
+    event.volunteerFormId,
+    formResponses
+  );
+  if (!validation.valid) {
+    throw new Error(validation.errors.join("; "));
+  }
+
+  return createVolunteerApplication({
+    event: event._id,
+    applicantInfo: {
+      ...applicantInfo,
+      email: applicantEmail,
+    },
+    formResponses: validation.normalizedResponses,
+    status: "pending",
+  });
+}

--- a/src/services/volunteerApplicationSubmitLogic.js
+++ b/src/services/volunteerApplicationSubmitLogic.js
@@ -1,0 +1,31 @@
+import { hasLinkedForm } from "./eventFormLogic.js";
+import { assertEventIsPublic } from "./eventPublicLogic.js";
+import { normalizeEmail } from "./eventRegistrationLogic.js";
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export function assertVolunteerApplicationAllowed(event) {
+  assertEventIsPublic(event);
+
+  if (!hasLinkedForm(event, "volunteerFormId")) {
+    throw new Error("Volunteer applications are not enabled for this event");
+  }
+}
+
+export function assertNoDuplicateVolunteerApplication(existingApplication) {
+  if (existingApplication) {
+    throw new Error(
+      "This email has already applied to volunteer for the event"
+    );
+  }
+}
+
+export function resolveApplicantEmail(applicantInfo = {}) {
+  const normalizedEmail = normalizeEmail(applicantInfo.email);
+
+  if (!EMAIL_REGEX.test(normalizedEmail)) {
+    throw new Error("A valid email is required to apply to volunteer");
+  }
+
+  return normalizedEmail;
+}

--- a/src/validators/eventRegistration.validator.js
+++ b/src/validators/eventRegistration.validator.js
@@ -1,0 +1,13 @@
+import Joi from "joi";
+
+export const eventRegistrationValidator = Joi.object({
+  guestInfo: Joi.object({
+    name: Joi.string().trim().allow("").optional(),
+    email: Joi.string().email().trim().allow("").optional(),
+    phone: Joi.string().trim().allow("").optional(),
+  }).default({}),
+  formResponses: Joi.object({
+    builtinFields: Joi.object().unknown(true).default({}),
+    customAnswers: Joi.object().unknown(true).default({}),
+  }).default({ builtinFields: {}, customAnswers: {} }),
+});

--- a/src/validators/volunteerApplicationSubmit.validator.js
+++ b/src/validators/volunteerApplicationSubmit.validator.js
@@ -1,0 +1,13 @@
+import Joi from "joi";
+
+export const volunteerApplicationSubmitValidator = Joi.object({
+  applicantInfo: Joi.object({
+    name: Joi.string().trim().allow("").optional(),
+    email: Joi.string().email().trim().required(),
+    phone: Joi.string().trim().allow("").optional(),
+  }).required(),
+  formResponses: Joi.object({
+    builtinFields: Joi.object().unknown(true).default({}),
+    customAnswers: Joi.object().unknown(true).default({}),
+  }).default({ builtinFields: {}, customAnswers: {} }),
+});

--- a/tests/public/events/eventCapacityService.test.js
+++ b/tests/public/events/eventCapacityService.test.js
@@ -65,4 +65,15 @@ describe("eventCapacityLogic", () => {
       checkCapacity(cancelledEvent, 1, { confirmedCount: 0 })
     ).toThrow("Cancelled events do not accept registrations");
   });
+
+  it("blocks draft events from accepting registrations", () => {
+    const draftEvent = { ...event, status: "draft" };
+
+    expect(() => assertEventAcceptsRegistrations(draftEvent)).toThrow(
+      "Only published events accept registrations"
+    );
+    expect(() => checkCapacity(draftEvent, 1, { confirmedCount: 0 })).toThrow(
+      "Only published events accept registrations"
+    );
+  });
 });

--- a/tests/public/events/eventPublicLogic.test.js
+++ b/tests/public/events/eventPublicLogic.test.js
@@ -1,0 +1,106 @@
+/*eslint-disable no-undef */
+import {
+  assertEventIsPublic,
+  toPublicEventDetail,
+  toPublicEventListItem,
+  toPublicFormSchema,
+  toPublicTicketType,
+} from "../../../src/services/eventPublicLogic.js";
+
+describe("eventPublicLogic", () => {
+  const formSchema = {
+    _id: "64a000000000000000000020",
+    builtinFields: [{ field: "email", required: true }],
+    customQuestions: [{ id: "q1", label: "Question", type: "text" }],
+    createdBy: "admin-id",
+  };
+  const event = {
+    _id: "64a000000000000000000010",
+    name: "Public Event",
+    description: "A public event",
+    eventDate: "2026-08-01T18:00:00.000Z",
+    type: "paid",
+    status: "published",
+    maxAttendees: 20,
+    venue: { name: "Main Hall" },
+    banner: { url: "https://example.com/banner.jpg", publicId: "banner-id" },
+    registrationFormId: formSchema,
+    volunteerFormId: formSchema,
+    ticketTypes: [
+      {
+        _id: "64a000000000000000000001",
+        name: "Early Bird",
+        pricePesewas: 5000,
+        maxQuantity: 10,
+        soldCount: 3,
+        expiresAt: "2026-08-02T18:00:00.000Z",
+        isActive: true,
+      },
+    ],
+    createdBy: { _id: "admin-id", email: "admin@example.com" },
+    createdAt: "2026-06-01T00:00:00.000Z",
+    updatedAt: "2026-06-02T00:00:00.000Z",
+  };
+
+  it("allows only published events to be public", () => {
+    expect(() => assertEventIsPublic(event)).not.toThrow();
+    expect(() => assertEventIsPublic(null)).toThrow("Event not found");
+    expect(() => assertEventIsPublic({ ...event, status: "draft" })).toThrow(
+      "Event not found"
+    );
+    expect(() => assertEventIsPublic({ ...event, status: "cancelled" })).toThrow(
+      "Event not found"
+    );
+  });
+
+  it("shapes public list items without internal event relationships", () => {
+    expect(toPublicEventListItem(event)).toEqual({
+      _id: event._id,
+      name: event.name,
+      description: event.description,
+      eventDate: event.eventDate,
+      type: event.type,
+      status: event.status,
+      maxAttendees: event.maxAttendees,
+      venue: event.venue,
+      banner: event.banner,
+      createdAt: event.createdAt,
+      updatedAt: event.updatedAt,
+    });
+  });
+
+  it("shapes public form schemas without owner metadata", () => {
+    expect(toPublicFormSchema(formSchema)).toEqual({
+      _id: formSchema._id,
+      builtinFields: formSchema.builtinFields,
+      customQuestions: formSchema.customQuestions,
+    });
+  });
+
+  it("shapes public ticket types without sold count", () => {
+    expect(toPublicTicketType(event.ticketTypes[0])).toEqual({
+      _id: event.ticketTypes[0]._id,
+      name: "Early Bird",
+      pricePesewas: 5000,
+      expiresAt: "2026-08-02T18:00:00.000Z",
+      isActive: true,
+      remainingQuantity: 7,
+    });
+  });
+
+  it("includes forms, ticket availability, and event spots on detail", () => {
+    expect(toPublicEventDetail(event, 6)).toMatchObject({
+      _id: event._id,
+      registrationForm: {
+        builtinFields: formSchema.builtinFields,
+        customQuestions: formSchema.customQuestions,
+      },
+      volunteerForm: {
+        builtinFields: formSchema.builtinFields,
+        customQuestions: formSchema.customQuestions,
+      },
+      ticketTypes: [{ remainingQuantity: 7 }],
+      spotsRemaining: 14,
+    });
+  });
+});

--- a/tests/public/events/eventRegistrationLogic.test.js
+++ b/tests/public/events/eventRegistrationLogic.test.js
@@ -1,0 +1,58 @@
+/*eslint-disable no-undef */
+import {
+  assertFreeEventRegistration,
+  assertNoDuplicateRegistration,
+  normalizeEmail,
+  resolveRegistrationEmail,
+} from "../../../src/services/eventRegistrationLogic.js";
+
+describe("eventRegistrationLogic", () => {
+  const freeEvent = {
+    type: "free",
+    status: "published",
+  };
+
+  it("normalizes email addresses for duplicate checks", () => {
+    expect(normalizeEmail(" Guest@Example.COM ")).toBe("guest@example.com");
+    expect(normalizeEmail(null)).toBe("");
+  });
+
+  it("prefers authenticated user email and falls back to guest info", () => {
+    expect(
+      resolveRegistrationEmail(
+        { type: "user", user: { email: "Member@Example.com" } },
+        { email: "guest@example.com" }
+      )
+    ).toBe("member@example.com");
+
+    expect(
+      resolveRegistrationEmail({ type: "guest" }, { email: "Guest@Example.com" })
+    ).toBe("guest@example.com");
+  });
+
+  it("requires a valid email address", () => {
+    expect(() => resolveRegistrationEmail({ type: "guest" }, {})).toThrow(
+      "A valid email is required to register for an event"
+    );
+    expect(() =>
+      resolveRegistrationEmail({ type: "guest" }, { email: "not-email" })
+    ).toThrow("A valid email is required to register for an event");
+  });
+
+  it("blocks duplicate registrations", () => {
+    expect(() => assertNoDuplicateRegistration(null)).not.toThrow();
+    expect(() => assertNoDuplicateRegistration({ _id: "registration-id" })).toThrow(
+      "This email is already registered for the event"
+    );
+  });
+
+  it("allows free RSVP only for published free events", () => {
+    expect(() => assertFreeEventRegistration(freeEvent)).not.toThrow();
+    expect(() =>
+      assertFreeEventRegistration({ ...freeEvent, type: "paid" })
+    ).toThrow("Free RSVP is only available for free events");
+    expect(() =>
+      assertFreeEventRegistration({ ...freeEvent, status: "draft" })
+    ).toThrow("Only published events accept registrations");
+  });
+});

--- a/tests/public/events/volunteerApplicationSubmitLogic.test.js
+++ b/tests/public/events/volunteerApplicationSubmitLogic.test.js
@@ -1,0 +1,45 @@
+/*eslint-disable no-undef */
+import {
+  assertNoDuplicateVolunteerApplication,
+  assertVolunteerApplicationAllowed,
+  resolveApplicantEmail,
+} from "../../../src/services/volunteerApplicationSubmitLogic.js";
+
+describe("volunteerApplicationSubmitLogic", () => {
+  const event = {
+    status: "published",
+    volunteerFormId: "64a000000000000000000020",
+  };
+
+  it("allows volunteer applications for published events with a volunteer form", () => {
+    expect(() => assertVolunteerApplicationAllowed(event)).not.toThrow();
+  });
+
+  it("rejects non-public events", () => {
+    expect(() =>
+      assertVolunteerApplicationAllowed({ ...event, status: "draft" })
+    ).toThrow("Event not found");
+  });
+
+  it("requires a configured volunteer form", () => {
+    expect(() =>
+      assertVolunteerApplicationAllowed({ ...event, volunteerFormId: null })
+    ).toThrow("Volunteer applications are not enabled for this event");
+  });
+
+  it("blocks duplicate volunteer applications", () => {
+    expect(() => assertNoDuplicateVolunteerApplication(null)).not.toThrow();
+    expect(() =>
+      assertNoDuplicateVolunteerApplication({ _id: "application-id" })
+    ).toThrow("This email has already applied to volunteer for the event");
+  });
+
+  it("normalizes and validates applicant email addresses", () => {
+    expect(resolveApplicantEmail({ email: " Applicant@Example.COM " })).toBe(
+      "applicant@example.com"
+    );
+    expect(() => resolveApplicantEmail({ email: "not-email" })).toThrow(
+      "A valid email is required to apply to volunteer"
+    );
+  });
+});


### PR DESCRIPTION
## Description
This branch exposes the public events API for published events while preserving the existing admin event management flow. It adds public-safe event list/detail responses, guest-or-user event mutations through `authenticateOptionalPrincipal`, form response validation, published-only guards, and email-based duplicate prevention for registrations and volunteer applications.

The implementation keeps payment fulfillment on the existing Paystack event ticket flow and adds focused unit coverage around public response shaping, registration guards, capacity publishing rules, and volunteer submission rules.

## Key Changes
- Add public `GET /events` and `GET /events/:id` routes with sanitized event responses.
- Add public `POST /events/:id/register` for free event RSVP with capacity checks, form validation, and email deduplication.
- Add public `POST /events/:id/checkout` for paid event ticket checkout using the existing Paystack event checkout service.
- Add public `POST /events/:id/volunteer-applications` with volunteer form validation and duplicate application prevention.
- Add shared event registration logic for email normalization, free-event guards, and duplicate registration checks.
- Add public event response-shaping logic for forms, ticket availability, and remaining event spots.
- Add model helpers to find active event registrations and volunteer applications by event/email.
- Extend registration capacity rules so only published events accept registrations.
- Add request validators for event registration and volunteer application submissions.
- Mount public event routes under `/api/v1/events` with route limiting.
- Add focused unit tests for public event shaping, registration guards, published-only capacity rules, and volunteer application submission guards.
