### PR TITLE
Refactor event form submissions to use identity fields as the source of truth

### DIFF
--- a/src/middleware/validator.middleware.js
+++ b/src/middleware/validator.middleware.js
@@ -177,7 +177,7 @@ export function validateEventTicketType(req, res, next) {
 }
 
 export function validateFormSchema(req, res, next) {
-  const { error } = formSchemaValidator.validate(req.body, {
+  const { error, value } = formSchemaValidator.validate(req.body, {
     abortEarly: false,
   });
 
@@ -190,6 +190,7 @@ export function validateFormSchema(req, res, next) {
     );
   }
 
+  req.body = value;
   next();
 }
 

--- a/src/models/eventRegistration.mongo.js
+++ b/src/models/eventRegistration.mongo.js
@@ -47,10 +47,6 @@ const eventRegistrationSchema = new Schema(
       default: () => ({}),
     },
     formResponses: {
-      builtinFields: {
-        type: Schema.Types.Mixed,
-        default: {},
-      },
       customAnswers: {
         type: Schema.Types.Mixed,
         default: {},

--- a/src/models/formSchema.mongo.js
+++ b/src/models/formSchema.mongo.js
@@ -2,6 +2,12 @@ import { Schema, model } from "mongoose";
 
 export const BUILTIN_FORM_FIELDS = ["name", "email", "phone"];
 export const FORM_QUESTION_TYPES = ["text", "textarea", "select", "checkbox"];
+export const DEFAULT_BUILTIN_FORM_FIELDS = [
+  { field: "name", required: true },
+  { field: "email", required: true },
+];
+const createDefaultBuiltinFormFields = () =>
+  DEFAULT_BUILTIN_FORM_FIELDS.map(fieldConfig => ({ ...fieldConfig }));
 
 const builtinFieldSchema = new Schema(
   {
@@ -56,7 +62,7 @@ const formSchema = new Schema(
   {
     builtinFields: {
       type: [builtinFieldSchema],
-      default: [],
+      default: createDefaultBuiltinFormFields,
     },
     customQuestions: {
       type: [customQuestionSchema],

--- a/src/models/volunteerApplication.mongo.js
+++ b/src/models/volunteerApplication.mongo.js
@@ -41,10 +41,6 @@ const volunteerApplicationSchema = new Schema(
       default: () => ({}),
     },
     formResponses: {
-      builtinFields: {
-        type: Schema.Types.Mixed,
-        default: {},
-      },
       customAnswers: {
         type: Schema.Types.Mixed,
         default: {},

--- a/src/services/eventCheckoutService.js
+++ b/src/services/eventCheckoutService.js
@@ -18,7 +18,7 @@ import {
   assertNoDuplicateRegistration,
   resolveRegistrationEmail,
 } from "./eventRegistrationService.js";
-import { validateFormResponses } from "./formValidationService.js";
+import { validateFormSubmission } from "./formValidationService.js";
 import {
   assertEventTicketCheckoutAllowed,
   buildEventPurchaseData,
@@ -52,17 +52,22 @@ export async function initializeEventTicketCheckout({
   );
   assertNoDuplicateRegistration(existingRegistration);
 
-  let normalizedResponses = { builtinFields: {}, customAnswers: {} };
+  let normalizedGuestInfo = {};
+  let normalizedResponses = { customAnswers: {} };
   if (event.registrationFormId) {
-    const validation = validateFormResponses(
-      event.registrationFormId,
-      formResponses
-    );
+    const validation = validateFormSubmission(event.registrationFormId, {
+      identity: guestInfo,
+      customAnswers: formResponses?.customAnswers ?? {},
+      resolvedEmail: registrationEmail,
+    });
     if (!validation.valid) {
       throw new Error(validation.errors.join("; "));
     }
 
-    normalizedResponses = validation.normalizedResponses;
+    normalizedGuestInfo = validation.normalizedIdentity;
+    normalizedResponses = {
+      customAnswers: validation.normalizedCustomAnswers,
+    };
   }
 
   const ticketType = event.ticketTypes.id(ticketTypeId);
@@ -89,6 +94,7 @@ export async function initializeEventTicketCheckout({
     user: principal?._id ?? null,
     guestInfo: {
       ...guestInfo,
+      ...normalizedGuestInfo,
       email: registrationEmail,
     },
     formResponses: normalizedResponses,

--- a/src/services/eventRegistrationService.js
+++ b/src/services/eventRegistrationService.js
@@ -4,7 +4,7 @@ import {
 } from "../models/eventRegistration.model.js";
 import { getEventById } from "../models/event.model.js";
 import { hasCapacity } from "./eventCapacityService.js";
-import { validateFormResponses } from "./formValidationService.js";
+import { validateFormSubmission } from "./formValidationService.js";
 import { assertEventIsPublic } from "./eventPublicService.js";
 import {
   assertFreeEventRegistration,
@@ -20,7 +20,6 @@ export {
 } from "./eventRegistrationLogic.js";
 
 const EMPTY_FORM_RESPONSES = {
-  builtinFields: {},
   customAnswers: {},
 };
 
@@ -41,17 +40,22 @@ export async function registerForFreeEvent({
   );
   assertNoDuplicateRegistration(existingRegistration);
 
+  let normalizedGuestInfo = {};
   let normalizedResponses = EMPTY_FORM_RESPONSES;
   if (event.registrationFormId) {
-    const validation = validateFormResponses(
-      event.registrationFormId,
-      formResponses
-    );
+    const validation = validateFormSubmission(event.registrationFormId, {
+      identity: guestInfo,
+      customAnswers: formResponses?.customAnswers ?? {},
+      resolvedEmail: registrationEmail,
+    });
     if (!validation.valid) {
       throw new Error(validation.errors.join("; "));
     }
 
-    normalizedResponses = validation.normalizedResponses;
+    normalizedGuestInfo = validation.normalizedIdentity;
+    normalizedResponses = {
+      customAnswers: validation.normalizedCustomAnswers,
+    };
   }
 
   const hasRemainingCapacity = await hasCapacity(event, 1);
@@ -64,6 +68,7 @@ export async function registerForFreeEvent({
     user: principal?._id ?? null,
     guestInfo: {
       ...guestInfo,
+      ...normalizedGuestInfo,
       email: registrationEmail,
     },
     formResponses: normalizedResponses,

--- a/src/services/formValidationLogic.js
+++ b/src/services/formValidationLogic.js
@@ -25,20 +25,21 @@ function normalizeString(value) {
   return typeof value === "string" ? value.trim() : value;
 }
 
-function validateBuiltinFields(schemaFields, responses, errors) {
-  const configuredFields = new Set(schemaFields.map(({ field }) => field));
-  const submittedFields = Object.keys(responses);
-  const normalized = {};
+function normalizeIdentity(identity = {}, overrides = {}) {
+  return {
+    ...identity,
+    ...Object.fromEntries(
+      Object.entries(overrides).filter(([, value]) => !isMissing(value))
+    ),
+  };
+}
 
-  for (const field of submittedFields) {
-    if (!configuredFields.has(field)) {
-      errors.push(`Unknown builtin field submitted: ${field}`);
-    }
-  }
+function validateBuiltinFields(schemaFields, identity, errors) {
+  const normalized = {};
 
   for (const fieldConfig of schemaFields) {
     const { field, required } = fieldConfig;
-    const value = responses[field];
+    const value = identity[field];
 
     if (required && isMissing(value)) {
       errors.push(`${field} is required`);
@@ -138,15 +139,10 @@ function validateCustomQuestions(questions, answers, errors) {
 export function validateFormResponses(formSchema, responses = {}) {
   const schema = toPlainFormSchema(formSchema);
   const errors = [];
-  const builtinResponses = responses.builtinFields ?? {};
   const customAnswers = responses.customAnswers ?? {};
 
-  if (
-    typeof builtinResponses !== "object" ||
-    Array.isArray(builtinResponses) ||
-    builtinResponses === null
-  ) {
-    errors.push("builtinFields responses must be an object");
+  if (responses.builtinFields !== undefined) {
+    errors.push("formResponses.builtinFields is no longer supported");
   }
 
   if (
@@ -157,11 +153,6 @@ export function validateFormResponses(formSchema, responses = {}) {
     errors.push("customAnswers responses must be an object");
   }
 
-  const safeBuiltinResponses = errors.includes(
-    "builtinFields responses must be an object"
-  )
-    ? {}
-    : builtinResponses;
   const safeCustomAnswers = errors.includes(
     "customAnswers responses must be an object"
   )
@@ -169,11 +160,6 @@ export function validateFormResponses(formSchema, responses = {}) {
     : customAnswers;
 
   const normalizedResponses = {
-    builtinFields: validateBuiltinFields(
-      schema.builtinFields ?? [],
-      safeBuiltinResponses,
-      errors
-    ),
     customAnswers: validateCustomQuestions(
       schema.customQuestions ?? [],
       safeCustomAnswers,
@@ -185,5 +171,74 @@ export function validateFormResponses(formSchema, responses = {}) {
     valid: errors.length === 0,
     errors,
     normalizedResponses,
+  };
+}
+
+export function validateIdentityInfo(
+  schemaBuiltinFields = [],
+  identity = {},
+  { resolvedEmail } = {}
+) {
+  const errors = [];
+  const identityInput = normalizeIdentity(identity, { email: resolvedEmail });
+
+  if (
+    typeof identityInput !== "object" ||
+    Array.isArray(identityInput) ||
+    identityInput === null
+  ) {
+    errors.push("identity info must be an object");
+  }
+
+  const normalizedIdentity = errors.includes("identity info must be an object")
+    ? {}
+    : validateBuiltinFields(schemaBuiltinFields, identityInput, errors);
+
+  return {
+    valid: errors.length === 0,
+    errors,
+    normalizedIdentity,
+  };
+}
+
+export function validateFormSubmission(
+  formSchema,
+  { identity = {}, customAnswers = {}, resolvedEmail } = {}
+) {
+  const schema = toPlainFormSchema(formSchema);
+  const errors = [];
+
+  if (
+    typeof customAnswers !== "object" ||
+    Array.isArray(customAnswers) ||
+    customAnswers === null
+  ) {
+    errors.push("customAnswers responses must be an object");
+  }
+
+  const identityValidation = validateIdentityInfo(
+    schema.builtinFields ?? [],
+    identity,
+    { resolvedEmail }
+  );
+  errors.push(...identityValidation.errors);
+
+  const safeCustomAnswers = errors.includes(
+    "customAnswers responses must be an object"
+  )
+    ? {}
+    : customAnswers;
+
+  const normalizedCustomAnswers = validateCustomQuestions(
+    schema.customQuestions ?? [],
+    safeCustomAnswers,
+    errors
+  );
+
+  return {
+    valid: errors.length === 0,
+    errors,
+    normalizedIdentity: identityValidation.normalizedIdentity,
+    normalizedCustomAnswers,
   };
 }

--- a/src/services/formValidationService.js
+++ b/src/services/formValidationService.js
@@ -1,1 +1,5 @@
-export { validateFormResponses } from "./formValidationLogic.js";
+export {
+  validateFormResponses,
+  validateFormSubmission,
+  validateIdentityInfo,
+} from "./formValidationLogic.js";

--- a/src/services/volunteerApplicationService.js
+++ b/src/services/volunteerApplicationService.js
@@ -3,7 +3,7 @@ import {
   createVolunteerApplication,
   findActiveVolunteerApplicationByEventAndEmail,
 } from "../models/volunteerApplication.model.js";
-import { validateFormResponses } from "./formValidationService.js";
+import { validateFormSubmission } from "./formValidationService.js";
 import {
   assertNoDuplicateVolunteerApplication,
   assertVolunteerApplicationAllowed,
@@ -24,7 +24,6 @@ export {
 } from "./volunteerApplicationSubmitLogic.js";
 
 const EMPTY_FORM_RESPONSES = {
-  builtinFields: {},
   customAnswers: {},
 };
 
@@ -44,10 +43,10 @@ export async function submitVolunteerApplication({
     );
   assertNoDuplicateVolunteerApplication(existingApplication);
 
-  const validation = validateFormResponses(
-    event.volunteerFormId,
-    formResponses
-  );
+  const validation = validateFormSubmission(event.volunteerFormId, {
+    identity: applicantInfo,
+    customAnswers: formResponses?.customAnswers ?? {},
+  });
   if (!validation.valid) {
     throw new Error(validation.errors.join("; "));
   }
@@ -56,9 +55,12 @@ export async function submitVolunteerApplication({
     event: event._id,
     applicantInfo: {
       ...applicantInfo,
+      ...validation.normalizedIdentity,
       email: applicantEmail,
     },
-    formResponses: validation.normalizedResponses,
+    formResponses: {
+      customAnswers: validation.normalizedCustomAnswers,
+    },
     status: "pending",
   });
 }

--- a/src/validators/eventCheckout.validator.js
+++ b/src/validators/eventCheckout.validator.js
@@ -19,7 +19,9 @@ export const eventTicketCheckoutValidator = Joi.object({
     phone: Joi.string().trim().allow("").optional(),
   }).default({}),
   formResponses: Joi.object({
-    builtinFields: Joi.object().unknown(true).default({}),
+    builtinFields: Joi.forbidden().messages({
+      "any.unknown": "formResponses.builtinFields is no longer supported",
+    }),
     customAnswers: Joi.object().unknown(true).default({}),
-  }).default({ builtinFields: {}, customAnswers: {} }),
+  }).default({ customAnswers: {} }),
 });

--- a/src/validators/eventRegistration.validator.js
+++ b/src/validators/eventRegistration.validator.js
@@ -7,7 +7,9 @@ export const eventRegistrationValidator = Joi.object({
     phone: Joi.string().trim().allow("").optional(),
   }).default({}),
   formResponses: Joi.object({
-    builtinFields: Joi.object().unknown(true).default({}),
+    builtinFields: Joi.forbidden().messages({
+      "any.unknown": "formResponses.builtinFields is no longer supported",
+    }),
     customAnswers: Joi.object().unknown(true).default({}),
-  }).default({ builtinFields: {}, customAnswers: {} }),
+  }).default({ customAnswers: {} }),
 });

--- a/src/validators/formSchema.validator.js
+++ b/src/validators/formSchema.validator.js
@@ -2,8 +2,12 @@ import Joi from "joi";
 import mongoose from "mongoose";
 import {
   BUILTIN_FORM_FIELDS,
+  DEFAULT_BUILTIN_FORM_FIELDS,
   FORM_QUESTION_TYPES,
 } from "../models/formSchema.mongo.js";
+
+const createDefaultBuiltinFormFields = () =>
+  DEFAULT_BUILTIN_FORM_FIELDS.map(fieldConfig => ({ ...fieldConfig }));
 
 const uniqueBy = key => (value, helpers) => {
   if (!Array.isArray(value)) return value;
@@ -45,7 +49,7 @@ export const formSchemaValidator = Joi.object({
   builtinFields: Joi.array()
     .items(builtinFieldValidator)
     .custom(uniqueBy("field"), "Unique builtin field validation")
-    .default([]),
+    .default(createDefaultBuiltinFormFields),
   customQuestions: Joi.array()
     .items(customQuestionValidator)
     .custom(uniqueBy("id"), "Unique custom question validation")

--- a/src/validators/volunteerApplicationSubmit.validator.js
+++ b/src/validators/volunteerApplicationSubmit.validator.js
@@ -7,7 +7,9 @@ export const volunteerApplicationSubmitValidator = Joi.object({
     phone: Joi.string().trim().allow("").optional(),
   }).required(),
   formResponses: Joi.object({
-    builtinFields: Joi.object().unknown(true).default({}),
+    builtinFields: Joi.forbidden().messages({
+      "any.unknown": "formResponses.builtinFields is no longer supported",
+    }),
     customAnswers: Joi.object().unknown(true).default({}),
-  }).default({ builtinFields: {}, customAnswers: {} }),
+  }).default({ customAnswers: {} }),
 });

--- a/tests/public/events/eventRegistrationModel.test.js
+++ b/tests/public/events/eventRegistrationModel.test.js
@@ -12,10 +12,6 @@ describe("EventRegistration model", () => {
         phone: "0240000000",
       },
       formResponses: {
-        builtinFields: {
-          name: "Ama",
-          email: "ama@example.com",
-        },
         customAnswers: {
           dietary: "vegetarian",
         },
@@ -27,6 +23,7 @@ describe("EventRegistration model", () => {
     expect(validationError).toBeUndefined();
     expect(registration.status).toBe("confirmed");
     expect(registration.guestInfo.email).toBe("ama@example.com");
+    expect(registration.formResponses.builtinFields).toBeUndefined();
     expect(registration.formResponses.customAnswers).toEqual({
       dietary: "vegetarian",
     });

--- a/tests/public/events/volunteerApplicationModel.test.js
+++ b/tests/public/events/volunteerApplicationModel.test.js
@@ -12,10 +12,6 @@ describe("VolunteerApplication model", () => {
         phone: "0240000000",
       },
       formResponses: {
-        builtinFields: {
-          name: "Ama",
-          email: "ama@example.com",
-        },
         customAnswers: {
           availability: "Weekends",
           hasExperience: true,
@@ -28,10 +24,7 @@ describe("VolunteerApplication model", () => {
     expect(validationError).toBeUndefined();
     expect(application.status).toBe("pending");
     expect(application.applicantInfo.email).toBe("ama@example.com");
-    expect(application.formResponses.builtinFields).toEqual({
-      name: "Ama",
-      email: "ama@example.com",
-    });
+    expect(application.formResponses.builtinFields).toBeUndefined();
     expect(application.formResponses.customAnswers).toEqual({
       availability: "Weekends",
       hasExperience: true,

--- a/tests/public/forms/formValidationService.test.js
+++ b/tests/public/forms/formValidationService.test.js
@@ -1,5 +1,8 @@
 /*eslint-disable no-undef */
-import { validateFormResponses } from "../../../src/services/formValidationLogic.js";
+import {
+  validateFormResponses,
+  validateFormSubmission,
+} from "../../../src/services/formValidationLogic.js";
 
 describe("formValidationLogic", () => {
   const formSchema = {
@@ -31,9 +34,9 @@ describe("formValidationLogic", () => {
     ],
   };
 
-  it("validates and normalizes configured builtin fields and custom answers", () => {
-    const result = validateFormResponses(formSchema, {
-      builtinFields: {
+  it("validates and normalizes configured identity fields and custom answers", () => {
+    const result = validateFormSubmission(formSchema, {
+      identity: {
         name: "  Ama  ",
         email: "ama@example.com",
         phone: "  0240000000  ",
@@ -48,24 +51,22 @@ describe("formValidationLogic", () => {
     expect(result).toEqual({
       valid: true,
       errors: [],
-      normalizedResponses: {
-        builtinFields: {
-          name: "Ama",
-          email: "ama@example.com",
-          phone: "0240000000",
-        },
-        customAnswers: {
-          dietary: "vegetarian",
-          notes: "Seat near the front",
-          consent: false,
-        },
+      normalizedIdentity: {
+        name: "Ama",
+        email: "ama@example.com",
+        phone: "0240000000",
+      },
+      normalizedCustomAnswers: {
+        dietary: "vegetarian",
+        notes: "Seat near the front",
+        consent: false,
       },
     });
   });
 
-  it("reports missing required builtin fields and custom questions", () => {
-    const result = validateFormResponses(formSchema, {
-      builtinFields: {
+  it("reports missing required identity fields and custom questions", () => {
+    const result = validateFormSubmission(formSchema, {
+      identity: {
         phone: "0240000000",
       },
       customAnswers: {},
@@ -82,9 +83,9 @@ describe("formValidationLogic", () => {
     );
   });
 
-  it("rejects unknown builtin fields and custom answers", () => {
-    const result = validateFormResponses(formSchema, {
-      builtinFields: {
+  it("rejects unknown custom answers", () => {
+    const result = validateFormSubmission(formSchema, {
+      identity: {
         name: "Ama",
         email: "ama@example.com",
         age: 34,
@@ -98,16 +99,14 @@ describe("formValidationLogic", () => {
 
     expect(result.valid).toBe(false);
     expect(result.errors).toEqual(
-      expect.arrayContaining([
-        "Unknown builtin field submitted: age",
-        "Unknown custom question submitted: shirtSize",
-      ])
+      expect.arrayContaining(["Unknown custom question submitted: shirtSize"])
     );
+    expect(result.errors).not.toContain("Unknown builtin field submitted: age");
   });
 
   it("rejects select answers outside the configured options", () => {
-    const result = validateFormResponses(formSchema, {
-      builtinFields: {
+    const result = validateFormSubmission(formSchema, {
+      identity: {
         name: "Ama",
         email: "ama@example.com",
       },
@@ -123,9 +122,9 @@ describe("formValidationLogic", () => {
     );
   });
 
-  it("rejects invalid builtin field values", () => {
-    const result = validateFormResponses(formSchema, {
-      builtinFields: {
+  it("rejects invalid configured identity field values", () => {
+    const result = validateFormSubmission(formSchema, {
+      identity: {
         name: "Ama",
         email: "not-an-email",
       },
@@ -137,6 +136,43 @@ describe("formValidationLogic", () => {
 
     expect(result.valid).toBe(false);
     expect(result.errors).toContain("email is invalid");
+  });
+
+  it("uses a resolved email when validating logged-in registrations", () => {
+    const result = validateFormSubmission(formSchema, {
+      identity: {
+        name: "Ama",
+      },
+      resolvedEmail: "account@example.com",
+      customAnswers: {
+        dietary: "none",
+        consent: true,
+      },
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.normalizedIdentity).toEqual({
+      name: "Ama",
+      email: "account@example.com",
+    });
+  });
+
+  it("rejects legacy builtin field response submissions", () => {
+    const result = validateFormResponses(formSchema, {
+      builtinFields: {
+        name: "Ama",
+        email: "ama@example.com",
+      },
+      customAnswers: {
+        dietary: "none",
+        consent: true,
+      },
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain(
+      "formResponses.builtinFields is no longer supported"
+    );
   });
 
   it("validates the same registration form schema for free and paid event responses", () => {
@@ -155,8 +191,8 @@ describe("formValidationLogic", () => {
       ],
     };
 
-    const freeEventResponse = validateFormResponses(registrationForm, {
-      builtinFields: {
+    const freeEventResponse = validateFormSubmission(registrationForm, {
+      identity: {
         name: "Ama",
         email: "ama@example.com",
       },
@@ -164,8 +200,8 @@ describe("formValidationLogic", () => {
         attendanceReason: "To learn",
       },
     });
-    const paidEventResponse = validateFormResponses(registrationForm, {
-      builtinFields: {
+    const paidEventResponse = validateFormSubmission(registrationForm, {
+      identity: {
         name: "Kojo",
         email: "kojo@example.com",
       },


### PR DESCRIPTION
## Description:

This branch removes the duplicated `formResponses.builtinFields` submission/storage path and makes `guestInfo` / `applicantInfo` the canonical source for built-in identity fields such as name, email, and phone. Form schema `builtinFields` still exists, but now acts only as configuration for which identity fields should be shown and required.

The refactor simplifies the API contract for registrations, paid checkouts, and volunteer applications by separating identity data from custom form answers. Clients now submit identity fields through `guestInfo` or `applicantInfo`, and submit event-specific questionnaire responses through `formResponses.customAnswers`.

## Key changes:

- Refactor form validation to validate schema `builtinFields` against `guestInfo` / `applicantInfo` instead of `formResponses.builtinFields`.
- Add `validateFormSubmission` and `validateIdentityInfo` helpers for identity-field and custom-answer validation.
- Reject legacy payloads that include `formResponses.builtinFields` with a clear validation error.
- Update free registration and paid checkout flows to persist only `guestInfo` plus `formResponses.customAnswers`.
- Update volunteer application flow to persist only `applicantInfo` plus `formResponses.customAnswers`.
- Remove `formResponses.builtinFields` from event registration and volunteer application Mongo schemas.
- Default new form schemas to required `name` and `email` built-in fields.
- Ensure validated form schema defaults are applied back onto `req.body`.
- Update model and validation tests to assert the new storage and validation behavior.

