### PR TITLE
Use event slugs for public event routes

### DIFF
--- a/postman/events-variables.example.json
+++ b/postman/events-variables.example.json
@@ -1,0 +1,87 @@
+{
+  "description": "Optional variables for the Misqabbi Events Postman collection. The collection already defines these as collection variables; copy them into your existing Postman environment only if you prefer environment-level variables.",
+  "recommendedBaseUrl": "http://localhost:5000/api/v1",
+  "variables": [
+    {
+      "key": "baseUrl",
+      "initialValue": "http://localhost:5000/api/v1",
+      "currentValue": "http://localhost:5000/api/v1",
+      "notes": "Reuse your existing baseUrl if it is already defined."
+    },
+    {
+      "key": "healthEventId",
+      "initialValue": "",
+      "currentValue": "",
+      "notes": "Set by Seed - Her Health Circle / Create Her Health Circle event."
+    },
+    {
+      "key": "healthEventSlug",
+      "initialValue": "",
+      "currentValue": "",
+      "notes": "Set by Seed - Her Health Circle / Create Her Health Circle event. Used by public event routes."
+    },
+    {
+      "key": "popupEventId",
+      "initialValue": "",
+      "currentValue": "",
+      "notes": "Set by Seed - Misqabbi Pop UP / Create Misqabbi Pop UP event."
+    },
+    {
+      "key": "popupEventSlug",
+      "initialValue": "",
+      "currentValue": "",
+      "notes": "Set by Seed - Misqabbi Pop UP / Create Misqabbi Pop UP event. Used by public event routes."
+    },
+    {
+      "key": "healthTicketTypeId",
+      "initialValue": "",
+      "currentValue": "",
+      "notes": "Set by Seed - Her Health Circle / Add GHC 100 General Registration ticket type."
+    },
+    {
+      "key": "checkoutReference",
+      "initialValue": "",
+      "currentValue": "",
+      "notes": "Set by Public - Guest flows / Initialize Her Health Circle checkout as guest."
+    },
+    {
+      "key": "popupRegistrationId",
+      "initialValue": "",
+      "currentValue": "",
+      "notes": "Set by Public - Guest flows / RSVP for Misqabbi Pop UP as guest."
+    },
+    {
+      "key": "healthRegistrationId",
+      "initialValue": "",
+      "currentValue": "",
+      "notes": "Set by Public - Guest flows / Initialize Her Health Circle checkout as guest."
+    },
+    {
+      "key": "volunteerApplicationId",
+      "initialValue": "",
+      "currentValue": "",
+      "notes": "Set by Public - Guest flows / Submit Misqabbi Pop UP volunteer application as guest."
+    },
+    {
+      "key": "popupVolunteerApplicationId",
+      "initialValue": "",
+      "currentValue": "",
+      "notes": "Alias for the saved Pop UP volunteer application ID."
+    }
+  ],
+  "runOrder": [
+    "Run your existing Admin Login request first so auth_token is present in the cookie jar.",
+    "Run Seed - Her Health Circle (paid).",
+    "Run Seed - Misqabbi Pop UP (free).",
+    "Run Public - Read.",
+    "Run Public - Guest flows (full flow).",
+    "Run Admin - Verify seeded data."
+  ],
+  "notes": [
+    "Admin routes use auth_token cookie authentication.",
+    "Public write routes require auth_token or guest_token.",
+    "Create Guest Session sets guest_token for public guest requests.",
+    "Banner uploads are intentionally excluded from this collection.",
+    "Paystack webhook simulation is intentionally excluded; use the logged authorizationUrl and then run payment verify."
+  ]
+}

--- a/postman/misqabbi-events.postman_collection.json
+++ b/postman/misqabbi-events.postman_collection.json
@@ -6,7 +6,11 @@
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "variable": [
-    { "key": "baseUrl", "value": "http://localhost:5000/api/v1", "type": "string" },
+    {
+      "key": "baseUrl",
+      "value": "http://localhost:5000/api/v1",
+      "type": "string"
+    },
     { "key": "healthEventId", "value": "", "type": "string" },
     { "key": "healthEventSlug", "value": "", "type": "string" },
     { "key": "popupEventId", "value": "", "type": "string" },
@@ -55,9 +59,7 @@
           "name": "Create Her Health Circle event",
           "request": {
             "method": "POST",
-            "header": [
-              { "key": "Content-Type", "value": "application/json" }
-            ],
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
             "body": {
               "mode": "raw",
               "raw": "{\n  \"name\": \"Her Health Circle\",\n  \"description\": \"An intimate Misqabbi health gathering for women focused on fibroid awareness. Join us for candid conversation, a panel of medical and wellness speakers, complimentary fibroid screening scans on site, and a clear referral pathway for treatment and ongoing care. A supportive space to learn, ask questions, and connect.\",\n  \"eventDate\": \"2026-07-26T10:00:00.000Z\",\n  \"type\": \"paid\",\n  \"maxAttendees\": 80,\n  \"venue\": {\n    \"name\": \"Accra Wellness Centre\",\n    \"address\": \"14 Independence Avenue, Accra, Ghana\",\n    \"url\": \"\"\n  }\n}"
@@ -92,9 +94,7 @@
           "name": "Set Her Health Circle registration form",
           "request": {
             "method": "PUT",
-            "header": [
-              { "key": "Content-Type", "value": "application/json" }
-            ],
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
             "body": {
               "mode": "raw",
               "raw": "{\n  \"builtinFields\": [\n    { \"field\": \"name\", \"required\": true },\n    { \"field\": \"email\", \"required\": true }\n  ],\n  \"customQuestions\": [\n    {\n      \"id\": \"fibroid_screening_history\",\n      \"label\": \"Have you previously had a fibroid screening or diagnosis?\",\n      \"type\": \"select\",\n      \"required\": true,\n      \"options\": [\"Yes\", \"No\", \"Not sure\"]\n    },\n    {\n      \"id\": \"scan_interest\",\n      \"label\": \"Would you like to be considered for a complimentary scan during the event?\",\n      \"type\": \"select\",\n      \"required\": true,\n      \"options\": [\"Yes, I would like a scan\", \"No, information only\"]\n    },\n    {\n      \"id\": \"panel_questions\",\n      \"label\": \"What would you like the panel to address?\",\n      \"type\": \"textarea\",\n      \"required\": false,\n      \"options\": []\n    }\n  ]\n}"
@@ -121,9 +121,7 @@
           "name": "Set Her Health Circle volunteer form",
           "request": {
             "method": "PUT",
-            "header": [
-              { "key": "Content-Type", "value": "application/json" }
-            ],
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
             "body": {
               "mode": "raw",
               "raw": "{\n  \"builtinFields\": [\n    { \"field\": \"name\", \"required\": true },\n    { \"field\": \"email\", \"required\": true }\n  ],\n  \"customQuestions\": [\n    {\n      \"id\": \"volunteer_role\",\n      \"label\": \"Preferred volunteer role\",\n      \"type\": \"select\",\n      \"required\": true,\n      \"options\": [\"Registration desk\", \"Usher\", \"Medical liaison\", \"Photography\"]\n    },\n    {\n      \"id\": \"availability\",\n      \"label\": \"Tell us when you are available on event day\",\n      \"type\": \"textarea\",\n      \"required\": true,\n      \"options\": []\n    }\n  ]\n}"
@@ -150,9 +148,7 @@
           "name": "Add GHC 100 General Registration ticket type",
           "request": {
             "method": "POST",
-            "header": [
-              { "key": "Content-Type", "value": "application/json" }
-            ],
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
             "body": {
               "mode": "raw",
               "raw": "{\n  \"name\": \"General Registration\",\n  \"pricePesewas\": 10000,\n  \"maxQuantity\": 80,\n  \"isActive\": true\n}"
@@ -183,9 +179,7 @@
           "name": "Publish Her Health Circle",
           "request": {
             "method": "PATCH",
-            "header": [
-              { "key": "Content-Type", "value": "application/json" }
-            ],
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
             "body": {
               "mode": "raw",
               "raw": "{\n  \"status\": \"published\"\n}"
@@ -218,9 +212,7 @@
           "name": "Create Misqabbi Pop UP event",
           "request": {
             "method": "POST",
-            "header": [
-              { "key": "Content-Type", "value": "application/json" }
-            ],
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
             "body": {
               "mode": "raw",
               "raw": "{\n  \"name\": \"Misqabbi Pop UP\",\n  \"description\": \"A free Misqabbi shopping pop-up. Browse new arrivals, exclusive in-person discounts, and meet the team. No ticket required; RSVP to reserve your spot.\",\n  \"eventDate\": \"2026-06-28T11:00:00.000Z\",\n  \"type\": \"free\",\n  \"maxAttendees\": 150,\n  \"venue\": {\n    \"name\": \"Jamestown Creative Hub\",\n    \"address\": \"32 Smith Lane, Accra, Ghana\",\n    \"url\": \"https://misqabbi.com\"\n  }\n}"
@@ -254,9 +246,7 @@
           "name": "Set Misqabbi Pop UP registration form",
           "request": {
             "method": "PUT",
-            "header": [
-              { "key": "Content-Type", "value": "application/json" }
-            ],
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
             "body": {
               "mode": "raw",
               "raw": "{\n  \"builtinFields\": [\n    { \"field\": \"name\", \"required\": true },\n    { \"field\": \"email\", \"required\": true }\n  ],\n  \"customQuestions\": [\n    {\n      \"id\": \"shopping_interest\",\n      \"label\": \"What are you most interested in at the pop-up?\",\n      \"type\": \"select\",\n      \"required\": true,\n      \"options\": [\"New arrivals\", \"Exclusive discounts\", \"Styling session\", \"Just browsing\"]\n    },\n    {\n      \"id\": \"bringing_guest\",\n      \"label\": \"Are you bringing a guest?\",\n      \"type\": \"checkbox\",\n      \"required\": false,\n      \"options\": []\n    }\n  ]\n}"
@@ -283,9 +273,7 @@
           "name": "Set Misqabbi Pop UP volunteer form",
           "request": {
             "method": "PUT",
-            "header": [
-              { "key": "Content-Type", "value": "application/json" }
-            ],
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
             "body": {
               "mode": "raw",
               "raw": "{\n  \"builtinFields\": [\n    { \"field\": \"name\", \"required\": true },\n    { \"field\": \"email\", \"required\": true }\n  ],\n  \"customQuestions\": [\n    {\n      \"id\": \"volunteer_role\",\n      \"label\": \"Preferred volunteer role\",\n      \"type\": \"select\",\n      \"required\": true,\n      \"options\": [\"Setup\", \"Sales floor\", \"Fitting assistant\"]\n    },\n    {\n      \"id\": \"shift_preference\",\n      \"label\": \"Preferred shift\",\n      \"type\": \"select\",\n      \"required\": true,\n      \"options\": [\"Morning\", \"Afternoon\", \"Full day\"]\n    }\n  ]\n}"
@@ -312,9 +300,7 @@
           "name": "Publish Misqabbi Pop UP",
           "request": {
             "method": "PATCH",
-            "header": [
-              { "key": "Content-Type", "value": "application/json" }
-            ],
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
             "body": {
               "mode": "raw",
               "raw": "{\n  \"status\": \"published\"\n}"
@@ -447,9 +433,7 @@
           "name": "RSVP for Misqabbi Pop UP as guest",
           "request": {
             "method": "POST",
-            "header": [
-              { "key": "Content-Type", "value": "application/json" }
-            ],
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
             "body": {
               "mode": "raw",
               "raw": "{\n  \"guestInfo\": {\n    \"name\": \"Ama Serwaa\",\n    \"email\": \"ama.serwaa+popup@test.example.com\"\n  },\n  \"formResponses\": {\n    \"customAnswers\": {\n      \"shopping_interest\": \"New arrivals\",\n      \"bringing_guest\": true\n    }\n  }\n}"
@@ -482,9 +466,7 @@
           "name": "Initialize Her Health Circle checkout as guest",
           "request": {
             "method": "POST",
-            "header": [
-              { "key": "Content-Type", "value": "application/json" }
-            ],
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
             "body": {
               "mode": "raw",
               "raw": "{\n  \"ticketTypeId\": \"{{healthTicketTypeId}}\",\n  \"quantity\": 1,\n  \"guestInfo\": {\n    \"name\": \"Esi Mensah\",\n    \"email\": \"esi.mensah+health@test.example.com\"\n  },\n  \"formResponses\": {\n    \"customAnswers\": {\n      \"fibroid_screening_history\": \"Not sure\",\n      \"scan_interest\": \"Yes, I would like a scan\",\n      \"panel_questions\": \"What symptoms should prompt a woman to seek screening?\"\n    }\n  }\n}"
@@ -543,9 +525,7 @@
           "name": "Submit Misqabbi Pop UP volunteer application as guest",
           "request": {
             "method": "POST",
-            "header": [
-              { "key": "Content-Type", "value": "application/json" }
-            ],
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
             "body": {
               "mode": "raw",
               "raw": "{\n  \"applicantInfo\": {\n    \"name\": \"Kofi Boateng\",\n    \"email\": \"kofi.boateng+popup-volunteer@test.example.com\"\n  },\n  \"formResponses\": {\n    \"customAnswers\": {\n      \"volunteer_role\": \"Sales floor\",\n      \"shift_preference\": \"Afternoon\"\n    }\n  }\n}"
@@ -583,7 +563,11 @@
       "item": [
         {
           "name": "Get Her Health Circle admin detail",
-          "request": { "method": "GET", "header": [], "url": "{{baseUrl}}/admin/events/{{healthEventId}}" },
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{baseUrl}}/admin/events/{{healthEventId}}"
+          },
           "event": [
             {
               "listen": "test",
@@ -603,7 +587,11 @@
         },
         {
           "name": "Get Misqabbi Pop UP admin detail",
-          "request": { "method": "GET", "header": [], "url": "{{baseUrl}}/admin/events/{{popupEventId}}" },
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{baseUrl}}/admin/events/{{popupEventId}}"
+          },
           "event": [
             {
               "listen": "test",
@@ -623,23 +611,33 @@
         },
         {
           "name": "List Misqabbi Pop UP attendees",
-          "request": { "method": "GET", "header": [], "url": "{{baseUrl}}/admin/events/{{popupEventId}}/attendees?page=1&limit=20" }
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{baseUrl}}/admin/events/{{popupEventId}}/attendees?page=1&limit=20"
+          }
         },
         {
           "name": "List Her Health Circle attendees",
-          "request": { "method": "GET", "header": [], "url": "{{baseUrl}}/admin/events/{{healthEventId}}/attendees?page=1&limit=20" }
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{baseUrl}}/admin/events/{{healthEventId}}/attendees?page=1&limit=20"
+          }
         },
         {
           "name": "List Misqabbi Pop UP volunteer applications",
-          "request": { "method": "GET", "header": [], "url": "{{baseUrl}}/admin/events/{{popupEventId}}/volunteer-applications?page=1&limit=20" }
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{baseUrl}}/admin/events/{{popupEventId}}/volunteer-applications?page=1&limit=20"
+          }
         },
         {
           "name": "Accept saved volunteer application",
           "request": {
             "method": "PATCH",
-            "header": [
-              { "key": "Content-Type", "value": "application/json" }
-            ],
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
             "body": {
               "mode": "raw",
               "raw": "{\n  \"status\": \"accepted\"\n}"
@@ -655,15 +653,17 @@
       "item": [
         {
           "name": "List admin events - published paid",
-          "request": { "method": "GET", "header": [], "url": "{{baseUrl}}/admin/events?page=1&limit=10&status=published&type=paid&q=health" }
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{baseUrl}}/admin/events?page=1&limit=10&status=published&type=paid&q=health"
+          }
         },
         {
           "name": "Update Her Health Circle core fields",
           "request": {
             "method": "PATCH",
-            "header": [
-              { "key": "Content-Type", "value": "application/json" }
-            ],
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
             "body": {
               "mode": "raw",
               "raw": "{\n  \"description\": \"Updated description for local testing. Re-run seed if you want the original copy back.\",\n  \"venue\": {\n    \"name\": \"Accra Wellness Centre\",\n    \"address\": \"14 Independence Avenue, Accra, Ghana\",\n    \"url\": \"\"\n  }\n}"
@@ -673,19 +673,25 @@
         },
         {
           "name": "Get Her Health Circle registration form",
-          "request": { "method": "GET", "header": [], "url": "{{baseUrl}}/admin/events/{{healthEventId}}/registration-form" }
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{baseUrl}}/admin/events/{{healthEventId}}/registration-form"
+          }
         },
         {
           "name": "Get Misqabbi Pop UP volunteer form",
-          "request": { "method": "GET", "header": [], "url": "{{baseUrl}}/admin/events/{{popupEventId}}/volunteer-form" }
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{baseUrl}}/admin/events/{{popupEventId}}/volunteer-form"
+          }
         },
         {
           "name": "Update Her Health Circle ticket type capacity",
           "request": {
             "method": "PATCH",
-            "header": [
-              { "key": "Content-Type", "value": "application/json" }
-            ],
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
             "body": {
               "mode": "raw",
               "raw": "{\n  \"maxQuantity\": 85,\n  \"isActive\": true\n}"
@@ -706,9 +712,7 @@
           "name": "Admin checkout test for Her Health Circle",
           "request": {
             "method": "POST",
-            "header": [
-              { "key": "Content-Type", "value": "application/json" }
-            ],
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
             "body": {
               "mode": "raw",
               "raw": "{\n  \"ticketTypeId\": \"{{healthTicketTypeId}}\",\n  \"quantity\": 1,\n  \"guestInfo\": {\n    \"name\": \"Admin Test Buyer\",\n    \"email\": \"admin-test-buyer@test.example.com\"\n  },\n  \"formResponses\": {\n    \"customAnswers\": {\n      \"fibroid_screening_history\": \"No\",\n      \"scan_interest\": \"No, information only\",\n      \"panel_questions\": \"Admin route checkout smoke test\"\n    }\n  }\n}"
@@ -741,19 +745,25 @@
       "item": [
         {
           "name": "List free public events",
-          "request": { "method": "GET", "header": [], "url": "{{baseUrl}}/events?page=1&limit=10&type=free" }
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{baseUrl}}/events?page=1&limit=10&type=free"
+          }
         },
         {
           "name": "Search public events",
-          "request": { "method": "GET", "header": [], "url": "{{baseUrl}}/events?page=1&limit=10&q=Misqabbi" }
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{baseUrl}}/events?page=1&limit=10&q=Misqabbi"
+          }
         },
         {
           "name": "Authenticated user RSVP variant - Pop UP",
           "request": {
             "method": "POST",
-            "header": [
-              { "key": "Content-Type", "value": "application/json" }
-            ],
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
             "body": {
               "mode": "raw",
               "raw": "{\n  \"guestInfo\": {\n    \"name\": \"Logged In RSVP\"\n  },\n  \"formResponses\": {\n    \"customAnswers\": {\n      \"shopping_interest\": \"Styling session\",\n      \"bringing_guest\": false\n    }\n  }\n}"
@@ -766,9 +776,7 @@
           "name": "Submit Her Health Circle volunteer application",
           "request": {
             "method": "POST",
-            "header": [
-              { "key": "Content-Type", "value": "application/json" }
-            ],
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
             "body": {
               "mode": "raw",
               "raw": "{\n  \"applicantInfo\": {\n    \"name\": \"Akua Health Volunteer\",\n    \"email\": \"akua.health-volunteer@test.example.com\"\n  },\n  \"formResponses\": {\n    \"customAnswers\": {\n      \"volunteer_role\": \"Registration desk\",\n      \"availability\": \"Available from 8am through event close.\"\n    }\n  }\n}"

--- a/postman/misqabbi-events.postman_collection.json
+++ b/postman/misqabbi-events.postman_collection.json
@@ -1,0 +1,783 @@
+{
+  "info": {
+    "_postman_id": "4c2551d9-f26d-47b5-91bc-7c41d43fa501",
+    "name": "Misqabbi Events",
+    "description": "Importable Events collection for Misqabbi backend. Reuse your existing admin login request first so the cookie jar has auth_token for localhost. Run folders in order: Seed - Her Health Circle, Seed - Misqabbi Pop UP, Public - Read, Public - Guest flows, Admin - Verify seeded data. The collection uses {{baseUrl}}, expected to be http://localhost:5000/api/v1 for local development. Public write flows need guest_token, created by POST {{baseUrl}}/auth/guest/session. Paid checkout returns data.authorizationUrl; open it manually, complete Paystack test payment, then run payment verify. Form schema builtinFields configure which identity fields are shown and required; submit guestInfo/applicantInfo plus formResponses.customAnswers only.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    { "key": "baseUrl", "value": "http://localhost:5000/api/v1", "type": "string" },
+    { "key": "healthEventId", "value": "", "type": "string" },
+    { "key": "healthEventSlug", "value": "", "type": "string" },
+    { "key": "popupEventId", "value": "", "type": "string" },
+    { "key": "popupEventSlug", "value": "", "type": "string" },
+    { "key": "healthTicketTypeId", "value": "", "type": "string" },
+    { "key": "checkoutReference", "value": "", "type": "string" },
+    { "key": "popupRegistrationId", "value": "", "type": "string" },
+    { "key": "healthRegistrationId", "value": "", "type": "string" },
+    { "key": "volunteerApplicationId", "value": "", "type": "string" },
+    { "key": "popupVolunteerApplicationId", "value": "", "type": "string" }
+  ],
+  "item": [
+    {
+      "name": "00 Setup",
+      "description": "Run your existing Admin Login request before admin folders. Run Create Guest Session before public write flows.",
+      "item": [
+        {
+          "name": "Create Guest Session",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "url": "{{baseUrl}}/auth/guest/session",
+            "description": "Creates or refreshes guest_token in the Postman cookie jar. Needed for public register, checkout, and volunteer application routes."
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Guest session request completed', function () {",
+                  "  pm.expect(pm.response.code).to.be.oneOf([200, 201]);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Seed - Her Health Circle (paid)",
+      "description": "Creates a paid fibroid-awareness event, adds registration/volunteer forms, adds a GHC 100 ticket type, and publishes the event.",
+      "item": [
+        {
+          "name": "Create Her Health Circle event",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Her Health Circle\",\n  \"description\": \"An intimate Misqabbi health gathering for women focused on fibroid awareness. Join us for candid conversation, a panel of medical and wellness speakers, complimentary fibroid screening scans on site, and a clear referral pathway for treatment and ongoing care. A supportive space to learn, ask questions, and connect.\",\n  \"eventDate\": \"2026-07-26T10:00:00.000Z\",\n  \"type\": \"paid\",\n  \"maxAttendees\": 80,\n  \"venue\": {\n    \"name\": \"Accra Wellness Centre\",\n    \"address\": \"14 Independence Avenue, Accra, Ghana\",\n    \"url\": \"\"\n  }\n}"
+            },
+            "url": "{{baseUrl}}/admin/events",
+            "description": "Requires admin auth_token cookie from your existing login request."
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Created draft paid event', function () {",
+                  "  pm.response.to.have.status(201);",
+                  "  const body = pm.response.json();",
+                  "  pm.expect(body.data).to.have.property('_id');",
+                  "  pm.expect(body.data).to.have.property('slug');",
+                  "  pm.expect(body.data.status).to.eql('draft');",
+                  "  pm.expect(body.data.type).to.eql('paid');",
+                  "  pm.collectionVariables.set('healthEventId', body.data._id);",
+                  "  pm.collectionVariables.set('healthEventSlug', body.data.slug);",
+                  "  console.log('healthEventId:', body.data._id);",
+                  "  console.log('healthEventSlug:', body.data.slug);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Set Her Health Circle registration form",
+          "request": {
+            "method": "PUT",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"builtinFields\": [\n    { \"field\": \"name\", \"required\": true },\n    { \"field\": \"email\", \"required\": true }\n  ],\n  \"customQuestions\": [\n    {\n      \"id\": \"fibroid_screening_history\",\n      \"label\": \"Have you previously had a fibroid screening or diagnosis?\",\n      \"type\": \"select\",\n      \"required\": true,\n      \"options\": [\"Yes\", \"No\", \"Not sure\"]\n    },\n    {\n      \"id\": \"scan_interest\",\n      \"label\": \"Would you like to be considered for a complimentary scan during the event?\",\n      \"type\": \"select\",\n      \"required\": true,\n      \"options\": [\"Yes, I would like a scan\", \"No, information only\"]\n    },\n    {\n      \"id\": \"panel_questions\",\n      \"label\": \"What would you like the panel to address?\",\n      \"type\": \"textarea\",\n      \"required\": false,\n      \"options\": []\n    }\n  ]\n}"
+            },
+            "url": "{{baseUrl}}/admin/events/{{healthEventId}}/registration-form"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Registration form saved', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "  const body = pm.response.json();",
+                  "  pm.expect(body.data.customQuestions.length).to.eql(3);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Set Her Health Circle volunteer form",
+          "request": {
+            "method": "PUT",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"builtinFields\": [\n    { \"field\": \"name\", \"required\": true },\n    { \"field\": \"email\", \"required\": true }\n  ],\n  \"customQuestions\": [\n    {\n      \"id\": \"volunteer_role\",\n      \"label\": \"Preferred volunteer role\",\n      \"type\": \"select\",\n      \"required\": true,\n      \"options\": [\"Registration desk\", \"Usher\", \"Medical liaison\", \"Photography\"]\n    },\n    {\n      \"id\": \"availability\",\n      \"label\": \"Tell us when you are available on event day\",\n      \"type\": \"textarea\",\n      \"required\": true,\n      \"options\": []\n    }\n  ]\n}"
+            },
+            "url": "{{baseUrl}}/admin/events/{{healthEventId}}/volunteer-form"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Volunteer form saved', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "  const body = pm.response.json();",
+                  "  pm.expect(body.data.customQuestions.length).to.eql(2);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Add GHC 100 General Registration ticket type",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"General Registration\",\n  \"pricePesewas\": 10000,\n  \"maxQuantity\": 80,\n  \"isActive\": true\n}"
+            },
+            "url": "{{baseUrl}}/admin/events/{{healthEventId}}/ticket-types"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Ticket type added and ID saved', function () {",
+                  "  pm.response.to.have.status(201);",
+                  "  const body = pm.response.json();",
+                  "  const ticket = (body.data.ticketTypes || []).find(item => item.name === 'General Registration');",
+                  "  pm.expect(ticket).to.be.an('object');",
+                  "  pm.expect(ticket.pricePesewas).to.eql(10000);",
+                  "  pm.collectionVariables.set('healthTicketTypeId', ticket._id);",
+                  "  console.log('healthTicketTypeId:', ticket._id);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Publish Her Health Circle",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"status\": \"published\"\n}"
+            },
+            "url": "{{baseUrl}}/admin/events/{{healthEventId}}/status"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Her Health Circle is published', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "  const body = pm.response.json();",
+                  "  pm.expect(body.data.status).to.eql('published');",
+                  "});"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Seed - Misqabbi Pop UP (free)",
+      "description": "Creates a free shopping pop-up event, adds forms, and publishes it.",
+      "item": [
+        {
+          "name": "Create Misqabbi Pop UP event",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Misqabbi Pop UP\",\n  \"description\": \"A free Misqabbi shopping pop-up. Browse new arrivals, exclusive in-person discounts, and meet the team. No ticket required; RSVP to reserve your spot.\",\n  \"eventDate\": \"2026-06-28T11:00:00.000Z\",\n  \"type\": \"free\",\n  \"maxAttendees\": 150,\n  \"venue\": {\n    \"name\": \"Jamestown Creative Hub\",\n    \"address\": \"32 Smith Lane, Accra, Ghana\",\n    \"url\": \"https://misqabbi.com\"\n  }\n}"
+            },
+            "url": "{{baseUrl}}/admin/events"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Created draft free event', function () {",
+                  "  pm.response.to.have.status(201);",
+                  "  const body = pm.response.json();",
+                  "  pm.expect(body.data).to.have.property('_id');",
+                  "  pm.expect(body.data).to.have.property('slug');",
+                  "  pm.expect(body.data.status).to.eql('draft');",
+                  "  pm.expect(body.data.type).to.eql('free');",
+                  "  pm.collectionVariables.set('popupEventId', body.data._id);",
+                  "  pm.collectionVariables.set('popupEventSlug', body.data.slug);",
+                  "  console.log('popupEventId:', body.data._id);",
+                  "  console.log('popupEventSlug:', body.data.slug);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Set Misqabbi Pop UP registration form",
+          "request": {
+            "method": "PUT",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"builtinFields\": [\n    { \"field\": \"name\", \"required\": true },\n    { \"field\": \"email\", \"required\": true }\n  ],\n  \"customQuestions\": [\n    {\n      \"id\": \"shopping_interest\",\n      \"label\": \"What are you most interested in at the pop-up?\",\n      \"type\": \"select\",\n      \"required\": true,\n      \"options\": [\"New arrivals\", \"Exclusive discounts\", \"Styling session\", \"Just browsing\"]\n    },\n    {\n      \"id\": \"bringing_guest\",\n      \"label\": \"Are you bringing a guest?\",\n      \"type\": \"checkbox\",\n      \"required\": false,\n      \"options\": []\n    }\n  ]\n}"
+            },
+            "url": "{{baseUrl}}/admin/events/{{popupEventId}}/registration-form"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Pop UP registration form saved', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "  const body = pm.response.json();",
+                  "  pm.expect(body.data.customQuestions.length).to.eql(2);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Set Misqabbi Pop UP volunteer form",
+          "request": {
+            "method": "PUT",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"builtinFields\": [\n    { \"field\": \"name\", \"required\": true },\n    { \"field\": \"email\", \"required\": true }\n  ],\n  \"customQuestions\": [\n    {\n      \"id\": \"volunteer_role\",\n      \"label\": \"Preferred volunteer role\",\n      \"type\": \"select\",\n      \"required\": true,\n      \"options\": [\"Setup\", \"Sales floor\", \"Fitting assistant\"]\n    },\n    {\n      \"id\": \"shift_preference\",\n      \"label\": \"Preferred shift\",\n      \"type\": \"select\",\n      \"required\": true,\n      \"options\": [\"Morning\", \"Afternoon\", \"Full day\"]\n    }\n  ]\n}"
+            },
+            "url": "{{baseUrl}}/admin/events/{{popupEventId}}/volunteer-form"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Pop UP volunteer form saved', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "  const body = pm.response.json();",
+                  "  pm.expect(body.data.customQuestions.length).to.eql(2);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Publish Misqabbi Pop UP",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"status\": \"published\"\n}"
+            },
+            "url": "{{baseUrl}}/admin/events/{{popupEventId}}/status"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Misqabbi Pop UP is published', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "  const body = pm.response.json();",
+                  "  pm.expect(body.data.status).to.eql('published');",
+                  "});"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Public - Read",
+      "description": "Public read requests that require no cookies.",
+      "item": [
+        {
+          "name": "List published events",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{baseUrl}}/events?page=1&limit=20"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Published events include seeded events when present', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "  const events = pm.response.json().data || [];",
+                  "  const names = events.map(event => event.name);",
+                  "  pm.expect(names).to.include('Her Health Circle');",
+                  "  pm.expect(names).to.include('Misqabbi Pop UP');",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Get Her Health Circle public detail",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{baseUrl}}/events/{{healthEventSlug}}"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Paid public detail includes ticket types', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "  const event = pm.response.json().data;",
+                  "  pm.expect(event.name).to.eql('Her Health Circle');",
+                  "  pm.expect(event.ticketTypes).to.be.an('array').that.is.not.empty;",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Get Misqabbi Pop UP public detail",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{baseUrl}}/events/{{popupEventSlug}}"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Free public detail loads', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "  const event = pm.response.json().data;",
+                  "  pm.expect(event.name).to.eql('Misqabbi Pop UP');",
+                  "  pm.expect(event.type).to.eql('free');",
+                  "});"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Public - Guest flows (full flow)",
+      "description": "Run Create Guest Session first. These requests use guest_token from the cookie jar.",
+      "item": [
+        {
+          "name": "Create Guest Session",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "url": "{{baseUrl}}/auth/guest/session"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Guest session ready', function () {",
+                  "  pm.expect(pm.response.code).to.be.oneOf([200, 201]);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "RSVP for Misqabbi Pop UP as guest",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"guestInfo\": {\n    \"name\": \"Ama Serwaa\",\n    \"email\": \"ama.serwaa+popup@test.example.com\"\n  },\n  \"formResponses\": {\n    \"customAnswers\": {\n      \"shopping_interest\": \"New arrivals\",\n      \"bringing_guest\": true\n    }\n  }\n}"
+            },
+            "url": "{{baseUrl}}/events/{{popupEventSlug}}/register"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Guest RSVP confirmed or duplicate exists', function () {",
+                  "  pm.expect(pm.response.code).to.be.oneOf([201, 400]);",
+                  "  const body = pm.response.json();",
+                  "  if (pm.response.code === 201) {",
+                  "    pm.expect(body.data.status).to.eql('confirmed');",
+                  "    pm.collectionVariables.set('popupRegistrationId', body.data._id);",
+                  "    console.log('popupRegistrationId:', body.data._id);",
+                  "  } else {",
+                  "    console.log('RSVP response:', body.error || body.message);",
+                  "  }",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Initialize Her Health Circle checkout as guest",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"ticketTypeId\": \"{{healthTicketTypeId}}\",\n  \"quantity\": 1,\n  \"guestInfo\": {\n    \"name\": \"Esi Mensah\",\n    \"email\": \"esi.mensah+health@test.example.com\"\n  },\n  \"formResponses\": {\n    \"customAnswers\": {\n      \"fibroid_screening_history\": \"Not sure\",\n      \"scan_interest\": \"Yes, I would like a scan\",\n      \"panel_questions\": \"What symptoms should prompt a woman to seek screening?\"\n    }\n  }\n}"
+            },
+            "url": "{{baseUrl}}/events/{{healthEventSlug}}/checkout"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Checkout initialized or duplicate pending exists', function () {",
+                  "  pm.expect(pm.response.code).to.be.oneOf([200, 400]);",
+                  "  const body = pm.response.json();",
+                  "  if (pm.response.code === 200) {",
+                  "    pm.expect(body.data.reference).to.be.a('string');",
+                  "    pm.expect(body.data.authorizationUrl).to.be.a('string');",
+                  "    pm.collectionVariables.set('checkoutReference', body.data.reference);",
+                  "    pm.collectionVariables.set('healthRegistrationId', body.data.eventRegistration._id);",
+                  "    console.log('checkoutReference:', body.data.reference);",
+                  "    console.log('Open Paystack URL manually:', body.data.authorizationUrl);",
+                  "  } else {",
+                  "    console.log('Checkout response:', body.error || body.message);",
+                  "  }",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Verify Her Health Circle checkout payment",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{baseUrl}}/payment/verify/{{checkoutReference}}",
+            "description": "Run this after completing payment using the authorizationUrl logged by checkout."
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Verify payment request completed', function () {",
+                  "  pm.expect(pm.response.code).to.be.oneOf([200, 400, 404]);",
+                  "  console.log('Payment verify response:', pm.response.text());",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Submit Misqabbi Pop UP volunteer application as guest",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"applicantInfo\": {\n    \"name\": \"Kofi Boateng\",\n    \"email\": \"kofi.boateng+popup-volunteer@test.example.com\"\n  },\n  \"formResponses\": {\n    \"customAnswers\": {\n      \"volunteer_role\": \"Sales floor\",\n      \"shift_preference\": \"Afternoon\"\n    }\n  }\n}"
+            },
+            "url": "{{baseUrl}}/events/{{popupEventSlug}}/volunteer-applications"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Volunteer application submitted or duplicate exists', function () {",
+                  "  pm.expect(pm.response.code).to.be.oneOf([201, 400]);",
+                  "  const body = pm.response.json();",
+                  "  if (pm.response.code === 201) {",
+                  "    pm.expect(body.data.status).to.eql('pending');",
+                  "    pm.collectionVariables.set('volunteerApplicationId', body.data._id);",
+                  "    pm.collectionVariables.set('popupVolunteerApplicationId', body.data._id);",
+                  "    console.log('volunteerApplicationId:', body.data._id);",
+                  "  } else {",
+                  "    console.log('Volunteer response:', body.error || body.message);",
+                  "  }",
+                  "});"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Admin - Verify seeded data",
+      "description": "Admin-only verification requests. Run your existing Admin Login first.",
+      "item": [
+        {
+          "name": "Get Her Health Circle admin detail",
+          "request": { "method": "GET", "header": [], "url": "{{baseUrl}}/admin/events/{{healthEventId}}" },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Admin detail has published paid event', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "  const event = pm.response.json().data;",
+                  "  pm.expect(event.status).to.eql('published');",
+                  "  pm.expect(event.ticketTypes).to.be.an('array').that.is.not.empty;",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Get Misqabbi Pop UP admin detail",
+          "request": { "method": "GET", "header": [], "url": "{{baseUrl}}/admin/events/{{popupEventId}}" },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Admin detail has published free event', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "  const event = pm.response.json().data;",
+                  "  pm.expect(event.status).to.eql('published');",
+                  "  pm.expect(event.type).to.eql('free');",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "List Misqabbi Pop UP attendees",
+          "request": { "method": "GET", "header": [], "url": "{{baseUrl}}/admin/events/{{popupEventId}}/attendees?page=1&limit=20" }
+        },
+        {
+          "name": "List Her Health Circle attendees",
+          "request": { "method": "GET", "header": [], "url": "{{baseUrl}}/admin/events/{{healthEventId}}/attendees?page=1&limit=20" }
+        },
+        {
+          "name": "List Misqabbi Pop UP volunteer applications",
+          "request": { "method": "GET", "header": [], "url": "{{baseUrl}}/admin/events/{{popupEventId}}/volunteer-applications?page=1&limit=20" }
+        },
+        {
+          "name": "Accept saved volunteer application",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"status\": \"accepted\"\n}"
+            },
+            "url": "{{baseUrl}}/admin/events/{{popupEventId}}/volunteer-applications/{{volunteerApplicationId}}"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Admin - Reference (all routes)",
+      "description": "Admin events route coverage beyond the main seed workflow. Requires auth_token cookie.",
+      "item": [
+        {
+          "name": "List admin events - published paid",
+          "request": { "method": "GET", "header": [], "url": "{{baseUrl}}/admin/events?page=1&limit=10&status=published&type=paid&q=health" }
+        },
+        {
+          "name": "Update Her Health Circle core fields",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"description\": \"Updated description for local testing. Re-run seed if you want the original copy back.\",\n  \"venue\": {\n    \"name\": \"Accra Wellness Centre\",\n    \"address\": \"14 Independence Avenue, Accra, Ghana\",\n    \"url\": \"\"\n  }\n}"
+            },
+            "url": "{{baseUrl}}/admin/events/{{healthEventId}}"
+          }
+        },
+        {
+          "name": "Get Her Health Circle registration form",
+          "request": { "method": "GET", "header": [], "url": "{{baseUrl}}/admin/events/{{healthEventId}}/registration-form" }
+        },
+        {
+          "name": "Get Misqabbi Pop UP volunteer form",
+          "request": { "method": "GET", "header": [], "url": "{{baseUrl}}/admin/events/{{popupEventId}}/volunteer-form" }
+        },
+        {
+          "name": "Update Her Health Circle ticket type capacity",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"maxQuantity\": 85,\n  \"isActive\": true\n}"
+            },
+            "url": "{{baseUrl}}/admin/events/{{healthEventId}}/ticket-types/{{healthTicketTypeId}}"
+          }
+        },
+        {
+          "name": "Delete Her Health Circle ticket type - only before sales",
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": "{{baseUrl}}/admin/events/{{healthEventId}}/ticket-types/{{healthTicketTypeId}}",
+            "description": "Use only in a disposable local DB. This should fail once soldCount is greater than 0."
+          }
+        },
+        {
+          "name": "Admin checkout test for Her Health Circle",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"ticketTypeId\": \"{{healthTicketTypeId}}\",\n  \"quantity\": 1,\n  \"guestInfo\": {\n    \"name\": \"Admin Test Buyer\",\n    \"email\": \"admin-test-buyer@test.example.com\"\n  },\n  \"formResponses\": {\n    \"customAnswers\": {\n      \"fibroid_screening_history\": \"No\",\n      \"scan_interest\": \"No, information only\",\n      \"panel_questions\": \"Admin route checkout smoke test\"\n    }\n  }\n}"
+            },
+            "url": "{{baseUrl}}/admin/events/{{healthEventId}}/checkout"
+          }
+        },
+        {
+          "name": "Get saved Pop UP attendee by ID",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{baseUrl}}/admin/events/{{popupEventId}}/attendees/{{popupRegistrationId}}",
+            "description": "Requires popupRegistrationId from the RSVP request."
+          }
+        },
+        {
+          "name": "Get saved volunteer application by ID",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{baseUrl}}/admin/events/{{popupEventId}}/volunteer-applications/{{volunteerApplicationId}}"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Public - Reference",
+      "description": "Extra public event route examples.",
+      "item": [
+        {
+          "name": "List free public events",
+          "request": { "method": "GET", "header": [], "url": "{{baseUrl}}/events?page=1&limit=10&type=free" }
+        },
+        {
+          "name": "Search public events",
+          "request": { "method": "GET", "header": [], "url": "{{baseUrl}}/events?page=1&limit=10&q=Misqabbi" }
+        },
+        {
+          "name": "Authenticated user RSVP variant - Pop UP",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"guestInfo\": {\n    \"name\": \"Logged In RSVP\"\n  },\n  \"formResponses\": {\n    \"customAnswers\": {\n      \"shopping_interest\": \"Styling session\",\n      \"bringing_guest\": false\n    }\n  }\n}"
+            },
+            "url": "{{baseUrl}}/events/{{popupEventSlug}}/register",
+            "description": "Run your existing Login first. Authenticated users use account email for duplicate checks; email in guestInfo is not required."
+          }
+        },
+        {
+          "name": "Submit Her Health Circle volunteer application",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"applicantInfo\": {\n    \"name\": \"Akua Health Volunteer\",\n    \"email\": \"akua.health-volunteer@test.example.com\"\n  },\n  \"formResponses\": {\n    \"customAnswers\": {\n      \"volunteer_role\": \"Registration desk\",\n      \"availability\": \"Available from 8am through event close.\"\n    }\n  }\n}"
+            },
+            "url": "{{baseUrl}}/events/{{healthEventSlug}}/volunteer-applications",
+            "description": "Requires auth_token or guest_token cookie."
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/controllers/events.public.controller.js
+++ b/src/controllers/events.public.controller.js
@@ -1,6 +1,6 @@
 import {
   countEvents,
-  getEventById,
+  getEventBySlug,
   getPaginatedEvents,
 } from "../models/event.model.js";
 import logger from "../config/logger.js";
@@ -16,6 +16,12 @@ import { submitVolunteerApplication } from "../services/volunteerApplicationServ
 import { formatResponse } from "../utils/responseFormatter.js";
 
 const PUBLISHED_EVENT_FILTER = "published";
+
+async function resolvePublishedEventBySlug(slug) {
+  const event = await getEventBySlug(slug);
+  assertEventIsPublic(event);
+  return event;
+}
 
 export async function getPublishedEvents(req, res) {
   try {
@@ -62,10 +68,9 @@ export async function getPublishedEvents(req, res) {
   }
 }
 
-export async function getPublishedEventById(req, res) {
+export async function getPublishedEventBySlug(req, res) {
   try {
-    const event = await getEventById(req.params.id);
-    assertEventIsPublic(event);
+    const event = await resolvePublishedEventBySlug(req.params.slug);
 
     const confirmedCount = await getConfirmedCount(event._id);
 
@@ -85,7 +90,7 @@ export async function getPublishedEventById(req, res) {
     }
 
     logger.error(
-      `[events.public.controller] Error loading public event ${req.params.id}: ${error.message}`
+      `[events.public.controller] Error loading public event ${req.params.slug}: ${error.message}`
     );
     res.status(500).json(
       formatResponse({
@@ -98,8 +103,9 @@ export async function getPublishedEventById(req, res) {
 
 export async function registerForFreeEventPublic(req, res) {
   try {
+    const event = await resolvePublishedEventBySlug(req.params.slug);
     const registration = await registerForFreeEvent({
-      eventId: req.params.id,
+      eventId: event._id,
       principal: req.principal,
       guestInfo: req.body.guestInfo,
       formResponses: req.body.formResponses,
@@ -122,7 +128,7 @@ export async function registerForFreeEventPublic(req, res) {
     }
 
     logger.error(
-      `[events.public.controller] Error registering for event ${req.params.id}: ${error.message}`
+      `[events.public.controller] Error registering for event ${req.params.slug}: ${error.message}`
     );
     res.status(400).json(
       formatResponse({
@@ -135,8 +141,9 @@ export async function registerForFreeEventPublic(req, res) {
 
 export async function initializeEventTicketCheckoutPublic(req, res) {
   try {
+    const event = await resolvePublishedEventBySlug(req.params.slug);
     const checkout = await initializeEventTicketCheckout({
-      eventId: req.params.id,
+      eventId: event._id,
       principal: req.principal,
       ticketTypeId: req.body.ticketTypeId,
       quantity: req.body.quantity,
@@ -161,7 +168,7 @@ export async function initializeEventTicketCheckoutPublic(req, res) {
     }
 
     logger.error(
-      `[events.public.controller] Error initializing checkout for event ${req.params.id}: ${error.message}`
+      `[events.public.controller] Error initializing checkout for event ${req.params.slug}: ${error.message}`
     );
     res.status(400).json(
       formatResponse({
@@ -174,8 +181,9 @@ export async function initializeEventTicketCheckoutPublic(req, res) {
 
 export async function submitVolunteerApplicationPublic(req, res) {
   try {
+    const event = await resolvePublishedEventBySlug(req.params.slug);
     const application = await submitVolunteerApplication({
-      eventId: req.params.id,
+      eventId: event._id,
       applicantInfo: req.body.applicantInfo,
       formResponses: req.body.formResponses,
     });
@@ -197,7 +205,7 @@ export async function submitVolunteerApplicationPublic(req, res) {
     }
 
     logger.error(
-      `[events.public.controller] Error submitting volunteer application for event ${req.params.id}: ${error.message}`
+      `[events.public.controller] Error submitting volunteer application for event ${req.params.slug}: ${error.message}`
     );
     res.status(400).json(
       formatResponse({

--- a/src/models/event.model.js
+++ b/src/models/event.model.js
@@ -2,6 +2,42 @@ import { Types } from "mongoose";
 import Event from "./event.mongo.js";
 import logger from "../config/logger.js";
 import { recomputeAutoTicketExpiries } from "../services/eventTicketLogic.js";
+import {
+  buildEventSlug,
+  buildEventSlugFamilyFilter,
+  buildUniqueEventSlug,
+  toRomanLower,
+} from "../utils/eventSlug.js";
+
+function isDuplicateSlugError(error) {
+  return error?.code === 11000 && Boolean(error?.keyPattern?.slug);
+}
+
+async function generateUniqueEventSlug(name) {
+  const baseSlug = buildEventSlug(name);
+  const existingCount = await Event.countDocuments(
+    buildEventSlugFamilyFilter(baseSlug)
+  );
+
+  let slug = buildUniqueEventSlug(baseSlug, existingCount);
+  let suffixNumber = existingCount + 2;
+
+  while (await Event.exists({ slug })) {
+    slug = `${baseSlug}-${toRomanLower(suffixNumber)}`;
+    suffixNumber += 1;
+  }
+
+  return slug;
+}
+
+async function createEventWithSlug(payload, adminId) {
+  return Event.create({
+    ...payload,
+    slug: await generateUniqueEventSlug(payload.name),
+    status: "draft",
+    createdBy: adminId,
+  });
+}
 
 export async function createEvent(eventData, adminId) {
   try {
@@ -10,12 +46,17 @@ export async function createEvent(eventData, adminId) {
     delete payload.registrationFormId;
     delete payload.volunteerFormId;
 
-    return await Event.create({
-      ...payload,
-      status: "draft",
-      createdBy: adminId,
-    });
+    return await createEventWithSlug(payload, adminId);
   } catch (error) {
+    if (isDuplicateSlugError(error)) {
+      const payload = { ...eventData };
+      delete payload.ticketTypes;
+      delete payload.registrationFormId;
+      delete payload.volunteerFormId;
+
+      return await createEventWithSlug(payload, adminId);
+    }
+
     logger.error(`[event.model] Error creating event: ${error.message}`);
     throw error;
   }
@@ -33,6 +74,17 @@ export async function getEventById(id) {
       .populate("volunteerFormId");
   } catch (error) {
     logger.error(`[event.model] Error finding event ${id}: ${error.message}`);
+    throw error;
+  }
+}
+
+export async function getEventBySlug(slug) {
+  try {
+    return await Event.findOne({ slug })
+      .populate("registrationFormId")
+      .populate("volunteerFormId");
+  } catch (error) {
+    logger.error(`[event.model] Error finding event ${slug}: ${error.message}`);
     throw error;
   }
 }
@@ -100,6 +152,7 @@ export async function updateEvent(id, updates) {
 
     delete payload.createdBy;
     delete payload.status;
+    delete payload.slug;
     delete payload.ticketTypes;
     delete payload.registrationFormId;
     delete payload.volunteerFormId;

--- a/src/models/event.mongo.js
+++ b/src/models/event.mongo.js
@@ -87,6 +87,13 @@ const eventSchema = new Schema(
       trim: true,
       index: true,
     },
+    slug: {
+      type: String,
+      required: true,
+      unique: true,
+      lowercase: true,
+      trim: true,
+    },
     description: {
       type: String,
       required: true,

--- a/src/routes/events.routes.js
+++ b/src/routes/events.routes.js
@@ -1,7 +1,7 @@
 import express from "express";
 import { rateLimiters } from "../config/rateLimiter.js";
 import {
-  getPublishedEventById,
+  getPublishedEventBySlug,
   getPublishedEvents,
   initializeEventTicketCheckoutPublic,
   registerForFreeEventPublic,
@@ -18,26 +18,26 @@ const router = express.Router();
 
 router.get("/", getPublishedEvents);
 router.post(
-  "/:id/register",
+  "/:slug/register",
   rateLimiters.strict,
   validateEventRegistration,
   authenticateOptionalPrincipal,
   registerForFreeEventPublic
 );
 router.post(
-  "/:id/checkout",
+  "/:slug/checkout",
   rateLimiters.strict,
   validateEventTicketCheckout,
   authenticateOptionalPrincipal,
   initializeEventTicketCheckoutPublic
 );
 router.post(
-  "/:id/volunteer-applications",
+  "/:slug/volunteer-applications",
   rateLimiters.strict,
   validateVolunteerApplicationSubmit,
   authenticateOptionalPrincipal,
   submitVolunteerApplicationPublic
 );
-router.get("/:id", getPublishedEventById);
+router.get("/:slug", getPublishedEventBySlug);
 
 export default router;

--- a/src/services/eventPublicLogic.js
+++ b/src/services/eventPublicLogic.js
@@ -52,6 +52,7 @@ export function toPublicEventListItem(event) {
 
   return {
     _id: getId(publicEvent),
+    slug: publicEvent.slug,
     name: publicEvent.name,
     description: publicEvent.description,
     eventDate: publicEvent.eventDate,

--- a/src/utils/eventSlug.js
+++ b/src/utils/eventSlug.js
@@ -1,0 +1,66 @@
+import slugify from "slugify";
+
+const ROMAN_NUMERALS = [
+  ["m", 1000],
+  ["cm", 900],
+  ["d", 500],
+  ["cd", 400],
+  ["c", 100],
+  ["xc", 90],
+  ["l", 50],
+  ["xl", 40],
+  ["x", 10],
+  ["ix", 9],
+  ["v", 5],
+  ["iv", 4],
+  ["i", 1],
+];
+
+export function toRomanLower(value) {
+  if (!Number.isInteger(value) || value < 1) {
+    throw new Error("Roman numeral value must be a positive integer");
+  }
+
+  let remaining = value;
+  let numeral = "";
+
+  for (const [symbol, amount] of ROMAN_NUMERALS) {
+    while (remaining >= amount) {
+      numeral += symbol;
+      remaining -= amount;
+    }
+  }
+
+  return numeral;
+}
+
+export function buildEventSlug(name) {
+  return (
+    slugify(name, {
+      lower: true,
+      strict: true,
+      trim: true,
+    }) || "event"
+  );
+}
+
+export function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function buildEventSlugFamilyFilter(baseSlug) {
+  return {
+    $or: [
+      { slug: baseSlug },
+      { slug: { $regex: `^${escapeRegExp(baseSlug)}-[ivxlcdm]+$` } },
+    ],
+  };
+}
+
+export function buildUniqueEventSlug(baseSlug, existingCount) {
+  if (existingCount === 0) {
+    return baseSlug;
+  }
+
+  return `${baseSlug}-${toRomanLower(existingCount + 1)}`;
+}

--- a/tests/public/events/eventPublicLogic.test.js
+++ b/tests/public/events/eventPublicLogic.test.js
@@ -16,6 +16,7 @@ describe("eventPublicLogic", () => {
   };
   const event = {
     _id: "64a000000000000000000010",
+    slug: "public-event",
     name: "Public Event",
     description: "A public event",
     eventDate: "2026-08-01T18:00:00.000Z",
@@ -56,6 +57,7 @@ describe("eventPublicLogic", () => {
   it("shapes public list items without internal event relationships", () => {
     expect(toPublicEventListItem(event)).toEqual({
       _id: event._id,
+      slug: event.slug,
       name: event.name,
       description: event.description,
       eventDate: event.eventDate,

--- a/tests/public/events/eventSlug.test.js
+++ b/tests/public/events/eventSlug.test.js
@@ -1,0 +1,47 @@
+/*eslint-disable no-undef */
+import {
+  buildEventSlug,
+  buildEventSlugFamilyFilter,
+  buildUniqueEventSlug,
+  toRomanLower,
+} from "../../../src/utils/eventSlug.js";
+
+describe("eventSlug", () => {
+  it("slugifies event names with hyphens", () => {
+    expect(buildEventSlug("Her Health Circle")).toBe("her-health-circle");
+    expect(buildEventSlug("  Her: Health & Circle!  ")).toBe(
+      "her-health-and-circle"
+    );
+  });
+
+  it("converts duplicate counts to lowercase Roman numeral suffixes", () => {
+    expect(toRomanLower(2)).toBe("ii");
+    expect(toRomanLower(3)).toBe("iii");
+    expect(toRomanLower(4)).toBe("iv");
+    expect(toRomanLower(9)).toBe("ix");
+    expect(toRomanLower(12)).toBe("xii");
+  });
+
+  it("builds unique slugs from existing family counts", () => {
+    expect(buildUniqueEventSlug("her-health-circle", 0)).toBe(
+      "her-health-circle"
+    );
+    expect(buildUniqueEventSlug("her-health-circle", 1)).toBe(
+      "her-health-circle-ii"
+    );
+    expect(buildUniqueEventSlug("her-health-circle", 2)).toBe(
+      "her-health-circle-iii"
+    );
+  });
+
+  it("builds a family filter for base and Roman-suffixed slugs", () => {
+    const filter = buildEventSlugFamilyFilter("her-health-circle");
+
+    expect(filter).toEqual({
+      $or: [
+        { slug: "her-health-circle" },
+        { slug: { $regex: "^her-health-circle-[ivxlcdm]+$" } },
+      ],
+    });
+  });
+});


### PR DESCRIPTION
## Description:
This branch adds immutable, auto-generated slugs to events and updates the public event API to use those slugs for cleaner, shareable signup, RSVP, checkout, and volunteer links. Slugs are generated from the event name, remain stable after creation, and use compact Roman-numeral suffixes when duplicate event names would otherwise collide.

## Key changes:
- Add a unique `slug` field to the Event schema.
- Generate event slugs automatically on event creation.
- Add reusable event slug helpers for slugification, slug-family matching, and Roman numeral suffixes.
- Add slug lookup support in the event model while keeping admin/internal flows on MongoDB event IDs.
- Replace public event route params from `:id` to `:slug`.
- Resolve public event detail, registration, checkout, and volunteer application requests by slug, then pass event `_id` into existing services.
- Include `slug` in public event list/detail responses so clients can build shareable URLs.
- Update focused tests for slug helpers and public event DTO shape.
- Update the Postman collection and variables example so public event requests use slug variables.