### PR TITLE
Fix event multipart validation and orphaned banner cleanup

### DIFF
--- a/src/controllers/events.admin.controller.js
+++ b/src/controllers/events.admin.controller.js
@@ -49,6 +49,7 @@ import {
 } from "../services/eventTicketService.js";
 import { assertVolunteerApplicationStatusTransition } from "../services/volunteerApplicationService.js";
 import { formatResponse } from "../utils/responseFormatter.js";
+import { cleanupUploadedEventBanner } from "../middleware/upload.middleware.js";
 
 export async function createEventAdmin(req, res) {
   try {
@@ -61,6 +62,7 @@ export async function createEventAdmin(req, res) {
       })
     );
   } catch (error) {
+    await cleanupUploadedEventBanner(req);
     logger.error(
       `[events.admin.controller] Error creating event: ${error.message}`
     );
@@ -183,6 +185,7 @@ export async function updateEventAdmin(req, res) {
       })
     );
   } catch (error) {
+    await cleanupUploadedEventBanner(req);
     logger.error(
       `[events.admin.controller] Error updating event ${req.params.id}: ${error.message}`
     );

--- a/src/controllers/events.admin.controller.js
+++ b/src/controllers/events.admin.controller.js
@@ -400,12 +400,7 @@ export async function getEventRegistrationFormAdmin(req, res) {
 
     const registrationFormId = getLinkedFormId(event);
     if (!registrationFormId) {
-      return res.status(404).json(
-        formatResponse({
-          success: false,
-          error: "Registration form not configured",
-        })
-      );
+      return res.status(200).json(formatResponse({ data: null }));
     }
 
     const registrationForm = await getFormSchemaById(registrationFormId);
@@ -479,12 +474,7 @@ export async function getEventVolunteerFormAdmin(req, res) {
 
     const volunteerFormId = getLinkedFormId(event, "volunteerFormId");
     if (!volunteerFormId) {
-      return res.status(404).json(
-        formatResponse({
-          success: false,
-          error: "Volunteer form not configured",
-        })
-      );
+      return res.status(200).json(formatResponse({ data: null }));
     }
 
     const volunteerForm = await getFormSchemaById(volunteerFormId);

--- a/src/middleware/upload.middleware.js
+++ b/src/middleware/upload.middleware.js
@@ -1,5 +1,5 @@
 import logger from "../config/logger.js";
-import cloudinary from "../config/cloudinary.js";
+import cloudinary, { deleteAssets } from "../config/cloudinary.js";
 
 export const getOptimisedUrl = (publicId, options = {}) => {
   return cloudinary.url(publicId, {
@@ -77,6 +77,7 @@ export const attachEventBannerToBody = (req, res, next) => {
 
   if (bannerFile) {
     const publicId = bannerFile.filename;
+    req.eventUploadedBannerPublicId = publicId;
     req.body.banner = {
       url: getOptimisedUrl(publicId),
       publicId,
@@ -88,6 +89,34 @@ export const attachEventBannerToBody = (req, res, next) => {
   );
   next();
 };
+
+export const normalizeEventMultipartBody = (req, res, next) => {
+  if (req.body.banner === "" || req.body.banner === "null") {
+    delete req.body.banner;
+  }
+
+  if (req.body.venue === "") {
+    delete req.body.venue;
+  }
+
+  next();
+};
+
+export async function cleanupUploadedEventBanner(req) {
+  const publicId = req.eventUploadedBannerPublicId;
+
+  if (!publicId) return;
+
+  try {
+    await deleteAssets([publicId]);
+  } catch (error) {
+    logger.warn(
+      `[upload.middleware] Failed to cleanup uploaded event banner ${publicId}: ${error.message}`
+    );
+  } finally {
+    delete req.eventUploadedBannerPublicId;
+  }
+}
 
 /**
  * After bespoke reference photo uploads (multer with referencePhotos field), map

--- a/src/middleware/upload.middleware.js
+++ b/src/middleware/upload.middleware.js
@@ -1,5 +1,6 @@
 import logger from "../config/logger.js";
 import cloudinary, { deleteAssets } from "../config/cloudinary.js";
+import { normalizeEventMultipartFields } from "../utils/eventMultipartBody.js";
 
 export const getOptimisedUrl = (publicId, options = {}) => {
   return cloudinary.url(publicId, {
@@ -91,14 +92,7 @@ export const attachEventBannerToBody = (req, res, next) => {
 };
 
 export const normalizeEventMultipartBody = (req, res, next) => {
-  if (req.body.banner === "" || req.body.banner === "null") {
-    delete req.body.banner;
-  }
-
-  if (req.body.venue === "") {
-    delete req.body.venue;
-  }
-
+  normalizeEventMultipartFields(req.body);
   next();
 };
 

--- a/src/middleware/validator.middleware.js
+++ b/src/middleware/validator.middleware.js
@@ -16,6 +16,7 @@ import { eventRegistrationValidator } from "../validators/eventRegistration.vali
 import { volunteerApplicationStatusValidator } from "../validators/volunteerApplication.validator.js";
 import { volunteerApplicationSubmitValidator } from "../validators/volunteerApplicationSubmit.validator.js";
 import { formatResponse } from "../utils/responseFormatter.js";
+import { cleanupUploadedEventBanner } from "./upload.middleware.js";
 
 export function validateUser(req, res, next) {
   const { error } = userValidator.validate(req.body, { abortEarly: false });
@@ -108,7 +109,7 @@ export function validateBespoke(req, res, next) {
   next();
 }
 
-export function validateEvent(req, res, next) {
+export async function validateEvent(req, res, next) {
   const isUpdate = req.method === "PATCH" || req.method === "PUT";
   const schema = isUpdate
     ? eventValidator.fork(
@@ -117,12 +118,13 @@ export function validateEvent(req, res, next) {
       )
     : eventValidator;
 
-  const { error } = schema.validate(req.body, {
+  const { error, value } = schema.validate(req.body, {
     abortEarly: false,
     allowUnknown: true,
   });
 
   if (error) {
+    await cleanupUploadedEventBanner(req);
     return res.status(400).json(
       formatResponse({
         success: false,
@@ -131,6 +133,7 @@ export function validateEvent(req, res, next) {
     );
   }
 
+  req.body = value;
   next();
 }
 

--- a/src/routes/admin.routes.js
+++ b/src/routes/admin.routes.js
@@ -15,6 +15,7 @@ import {
   attachEventBannerToBody,
   attachVariantImagesToBody,
   attachProductImagesToBody,
+  normalizeEventMultipartBody,
 } from "../middleware/upload.middleware.js";
 import { eventBannerUploads, productUploads } from "../config/cloudinary.js";
 
@@ -161,6 +162,7 @@ router.post(
   checkAdmin,
   eventBannerUploads.fields([{ name: "banner", maxCount: 1 }]),
   attachEventBannerToBody,
+  normalizeEventMultipartBody,
   validateEvent,
   createEventAdmin
 );
@@ -175,6 +177,7 @@ router.patch(
   checkAdmin,
   eventBannerUploads.fields([{ name: "banner", maxCount: 1 }]),
   attachEventBannerToBody,
+  normalizeEventMultipartBody,
   validateEvent,
   updateEventAdmin
 );

--- a/src/utils/eventMultipartBody.js
+++ b/src/utils/eventMultipartBody.js
@@ -1,0 +1,11 @@
+export function normalizeEventMultipartFields(body) {
+  if (body.banner === "" || body.banner === "null") {
+    delete body.banner;
+  }
+
+  if (body.venue === "") {
+    delete body.venue;
+  }
+
+  return body;
+}

--- a/src/validators/event.validator.js
+++ b/src/validators/event.validator.js
@@ -5,12 +5,15 @@ const venueValidator = Joi.object({
   name: Joi.string().trim().allow("").optional(),
   address: Joi.string().trim().allow("").optional(),
   url: Joi.string().trim().uri().allow("").optional(),
-}).optional();
+})
+  .empty("")
+  .optional();
 
 const bannerValidator = Joi.object({
   url: Joi.string().uri().required(),
   publicId: Joi.string().trim().required(),
 })
+  .empty("")
   .allow(null)
   .optional();
 

--- a/tests/public/events/eventMultipartNormalization.test.js
+++ b/tests/public/events/eventMultipartNormalization.test.js
@@ -1,0 +1,48 @@
+/*eslint-disable no-undef */
+import { jest } from "@jest/globals";
+import { normalizeEventMultipartBody } from "../../../src/middleware/upload.middleware.js";
+
+function normalize(body) {
+  const req = { body };
+  const next = jest.fn();
+
+  normalizeEventMultipartBody(req, {}, next);
+
+  return { body: req.body, next };
+}
+
+describe("event multipart normalization", () => {
+  it("strips empty optional banner and venue placeholders", () => {
+    const { body, next } = normalize({
+      banner: "",
+      venue: "",
+      name: "Summer Pop-up",
+    });
+
+    expect(body).toEqual({ name: "Summer Pop-up" });
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it("strips null string banner placeholders", () => {
+    const { body } = normalize({
+      banner: "null",
+      name: "Summer Pop-up",
+    });
+
+    expect(body).toEqual({ name: "Summer Pop-up" });
+  });
+
+  it("preserves attached banner objects", () => {
+    const banner = {
+      url: "https://res.cloudinary.com/demo/image/upload/v1/event/banner",
+      publicId: "misqabbi/events/banner",
+    };
+    const { body } = normalize({
+      banner,
+      venue: { name: "Studio" },
+    });
+
+    expect(body.banner).toEqual(banner);
+    expect(body.venue).toEqual({ name: "Studio" });
+  });
+});

--- a/tests/public/events/eventMultipartNormalization.test.js
+++ b/tests/public/events/eventMultipartNormalization.test.js
@@ -1,30 +1,23 @@
 /*eslint-disable no-undef */
-import { jest } from "@jest/globals";
-import { normalizeEventMultipartBody } from "../../../src/middleware/upload.middleware.js";
+import { normalizeEventMultipartFields } from "../../../src/utils/eventMultipartBody.js";
 
 function normalize(body) {
-  const req = { body };
-  const next = jest.fn();
-
-  normalizeEventMultipartBody(req, {}, next);
-
-  return { body: req.body, next };
+  return normalizeEventMultipartFields({ ...body });
 }
 
 describe("event multipart normalization", () => {
   it("strips empty optional banner and venue placeholders", () => {
-    const { body, next } = normalize({
+    const body = normalize({
       banner: "",
       venue: "",
       name: "Summer Pop-up",
     });
 
     expect(body).toEqual({ name: "Summer Pop-up" });
-    expect(next).toHaveBeenCalledTimes(1);
   });
 
   it("strips null string banner placeholders", () => {
-    const { body } = normalize({
+    const body = normalize({
       banner: "null",
       name: "Summer Pop-up",
     });
@@ -37,7 +30,7 @@ describe("event multipart normalization", () => {
       url: "https://res.cloudinary.com/demo/image/upload/v1/event/banner",
       publicId: "misqabbi/events/banner",
     };
-    const { body } = normalize({
+    const body = normalize({
       banner,
       venue: { name: "Studio" },
     });

--- a/tests/public/events/eventValidator.test.js
+++ b/tests/public/events/eventValidator.test.js
@@ -61,6 +61,37 @@ describe("eventValidator", () => {
     );
   });
 
+  it("treats empty banner fields as absent for multipart create payloads", () => {
+    const { error, value } = eventValidator.validate(
+      { ...validEvent, banner: "" },
+      { abortEarly: false }
+    );
+
+    expect(error).toBeUndefined();
+    expect(value.banner).toBeUndefined();
+  });
+
+  it("coerces numeric string attendee counts for multipart payloads", () => {
+    const { error, value } = eventValidator.validate(
+      { ...validEvent, maxAttendees: "50" },
+      { abortEarly: false }
+    );
+
+    expect(error).toBeUndefined();
+    expect(value.maxAttendees).toBe(50);
+  });
+
+  it("rejects empty attendee counts from multipart payloads", () => {
+    const { error } = eventValidator.validate(
+      { ...validEvent, maxAttendees: "" },
+      { abortEarly: false }
+    );
+
+    expect(error.details.map(detail => detail.message)).toContain(
+      "\"maxAttendees\" must be a number"
+    );
+  });
+
   it("accepts banner removal payloads for event updates", () => {
     const updateSchema = eventValidator.fork(
       ["name", "description", "eventDate", "type", "maxAttendees"],


### PR DESCRIPTION
Admin event create and update routes accept multipart form data, which often sends empty strings for optional fields such as banner and venue. Joi validation was rejecting these payloads, and banner images uploaded to Cloudinary were left behind when validation or persistence failed.

- Add `normalizeEventMultipartBody` middleware to strip empty or "null"` banner placeholders and empty venue strings before validation runs on admin create/update routes
- Enhance the event validator so empty banner and venue objects are treated as absent, and numeric attendee fields are coerced from multipart string values
- Track uploaded banner public IDs during multipart handling and delete orphaned Cloudinary assets when event validation fails or create/update controllers error
- Wire banner cleanup into `validateEvent` and the admin event create/update error paths so failed requests do not leave unused uploads behind
- Return `200` with `data: null` instead of `404` when admin registration or volunteer form endpoints are requested for events without a linked form
- Add unit tests for multipart body normalization and validator edge cases around banner, venue, and attendee fields