### PR TITLE
Block post-event registrations and add public upcoming/past listing

### DIFF
--- a/src/controllers/events.public.controller.js
+++ b/src/controllers/events.public.controller.js
@@ -13,6 +13,7 @@ import {
 import { initializeEventTicketCheckout } from "../services/eventCheckoutService.js";
 import { registerForFreeEvent } from "../services/eventRegistrationService.js";
 import { submitVolunteerApplication } from "../services/volunteerApplicationService.js";
+import { resolvePublicWhenFilter } from "../services/eventWhenLogic.js";
 import { formatResponse } from "../utils/responseFormatter.js";
 
 const PUBLISHED_EVENT_FILTER = "published";
@@ -25,13 +26,15 @@ async function resolvePublishedEventBySlug(slug) {
 
 export async function getPublishedEvents(req, res) {
   try {
-    const { page, limit, type, q } = req.query;
+    const { page, limit, type, q, when } = req.query;
     const pageNum = Math.max(parseInt(page) || 1, 1);
     const limitNum = Math.max(parseInt(limit) || 10, 1);
+    const whenFilter = resolvePublicWhenFilter(when);
     const filters = {
       status: PUBLISHED_EVENT_FILTER,
       type: type?.trim() || undefined,
       q: q?.trim() || undefined,
+      when: whenFilter === "all" ? undefined : whenFilter,
     };
 
     const total = await countEvents(filters);
@@ -56,6 +59,15 @@ export async function getPublishedEvents(req, res) {
       })
     );
   } catch (error) {
+    if (error.message.startsWith("Invalid when filter")) {
+      return res.status(400).json(
+        formatResponse({
+          success: false,
+          error: error.message,
+        })
+      );
+    }
+
     logger.error(
       `[events.public.controller] Error listing public events: ${error.message}`
     );

--- a/src/models/event.model.js
+++ b/src/models/event.model.js
@@ -89,24 +89,52 @@ export async function getEventBySlug(slug) {
   }
 }
 
+function buildEventListFilter(params = {}) {
+  const filter = {};
+
+  if (params.status) {
+    filter.status = params.status;
+  }
+
+  if (params.type) {
+    filter.type = params.type;
+  }
+
+  if (params.q && typeof params.q === "string") {
+    filter.$text = { $search: params.q };
+  }
+
+  if (params.when === "upcoming") {
+    filter.eventDate = { $gt: params.now ?? new Date() };
+  } else if (params.when === "past") {
+    filter.eventDate = { $lte: params.now ?? new Date() };
+  }
+
+  return filter;
+}
+
+function buildEventListSort(params = {}) {
+  const sort = {};
+
+  if (params.q && typeof params.q === "string") {
+    sort.score = { $meta: "textScore" };
+  }
+
+  if (params.when === "past") {
+    sort.eventDate = -1;
+  } else {
+    sort.eventDate = 1;
+  }
+
+  sort.createdAt = -1;
+  return sort;
+}
+
 export async function getPaginatedEvents(page = 1, limit = 10, params = {}) {
   try {
-    const filter = {};
-    const sort = { eventDate: 1, createdAt: -1 };
+    const filter = buildEventListFilter(params);
+    const sort = buildEventListSort(params);
     const skip = (page - 1) * limit;
-
-    if (params.status) {
-      filter.status = params.status;
-    }
-
-    if (params.type) {
-      filter.type = params.type;
-    }
-
-    if (params.q && typeof params.q === "string") {
-      filter.$text = { $search: params.q };
-      sort.score = { $meta: "textScore" };
-    }
 
     return await Event.find(filter)
       .sort(sort)
@@ -121,20 +149,7 @@ export async function getPaginatedEvents(page = 1, limit = 10, params = {}) {
 
 export async function countEvents(params = {}) {
   try {
-    const filter = {};
-
-    if (params.status) {
-      filter.status = params.status;
-    }
-
-    if (params.type) {
-      filter.type = params.type;
-    }
-
-    if (params.q && typeof params.q === "string") {
-      filter.$text = { $search: params.q };
-    }
-
+    const filter = buildEventListFilter(params);
     return await Event.countDocuments(filter);
   } catch (error) {
     logger.error(`[event.model] Error counting events: ${error.message}`);

--- a/src/services/eventCheckoutLogic.js
+++ b/src/services/eventCheckoutLogic.js
@@ -1,4 +1,5 @@
 import { hasEventCapacity } from "./eventCapacityLogic.js";
+import { assertEventRegistrationOpen } from "./eventRegistrationWindowLogic.js";
 import { isTicketPurchasable } from "./eventTicketLogic.js";
 
 export function calculateTicketPurchaseAmount(ticketType, quantity) {
@@ -28,7 +29,8 @@ export function assertEventTicketCheckoutAllowed(
   event,
   ticketType,
   quantity,
-  confirmedCount = 0
+  confirmedCount = 0,
+  now = new Date()
 ) {
   if (!event) {
     throw new Error("Event not found");
@@ -38,11 +40,13 @@ export function assertEventTicketCheckoutAllowed(
     throw new Error("Ticket type not found");
   }
 
+  assertEventRegistrationOpen(event, now);
+
   if (!hasEventCapacity(event, quantity, confirmedCount)) {
     throw new Error("Event does not have enough remaining capacity");
   }
 
-  if (!isTicketPurchasable(ticketType, event, quantity)) {
+  if (!isTicketPurchasable(ticketType, event, quantity, now)) {
     throw new Error("Ticket type is not available for purchase");
   }
 }

--- a/src/services/eventRegistrationLogic.js
+++ b/src/services/eventRegistrationLogic.js
@@ -1,4 +1,5 @@
 import { assertEventAcceptsRegistrations } from "./eventCapacityLogic.js";
+import { assertEventRegistrationOpen } from "./eventRegistrationWindowLogic.js";
 
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
@@ -26,8 +27,9 @@ export function assertNoDuplicateRegistration(existingRegistration) {
   }
 }
 
-export function assertFreeEventRegistration(event) {
+export function assertFreeEventRegistration(event, now = new Date()) {
   assertEventAcceptsRegistrations(event);
+  assertEventRegistrationOpen(event, now);
 
   if (event.type !== "free") {
     throw new Error("Free RSVP is only available for free events");

--- a/src/services/eventRegistrationWindowLogic.js
+++ b/src/services/eventRegistrationWindowLogic.js
@@ -1,0 +1,21 @@
+export const REGISTRATION_CLOSED_MESSAGE =
+  "Registration for this event has closed";
+
+export function isEventRegistrationOpen(event, now = new Date()) {
+  if (!event?.eventDate) {
+    return false;
+  }
+
+  const eventDate = new Date(event.eventDate);
+  if (Number.isNaN(eventDate.getTime())) {
+    return false;
+  }
+
+  return now < eventDate;
+}
+
+export function assertEventRegistrationOpen(event, now = new Date()) {
+  if (!isEventRegistrationOpen(event, now)) {
+    throw new Error(REGISTRATION_CLOSED_MESSAGE);
+  }
+}

--- a/src/services/eventTicketLogic.js
+++ b/src/services/eventTicketLogic.js
@@ -1,5 +1,3 @@
-const ONE_DAY_IN_MS = 24 * 60 * 60 * 1000;
-
 export function computeDefaultExpiry(eventDate) {
   const parsedEventDate = new Date(eventDate);
 
@@ -7,7 +5,7 @@ export function computeDefaultExpiry(eventDate) {
     throw new Error("Invalid event date");
   }
 
-  return new Date(parsedEventDate.getTime() + ONE_DAY_IN_MS);
+  return parsedEventDate;
 }
 
 export function canDeleteTicketType(ticketType) {

--- a/src/services/eventWhenLogic.js
+++ b/src/services/eventWhenLogic.js
@@ -1,0 +1,10 @@
+export const EVENT_WHEN_FILTERS = new Set(["upcoming", "past", "all"]);
+
+export function resolvePublicWhenFilter(when) {
+  const normalized = typeof when === "string" ? when.trim().toLowerCase() : "";
+  if (!normalized) return "upcoming";
+  if (!EVENT_WHEN_FILTERS.has(normalized)) {
+    throw new Error("Invalid when filter. Use upcoming, past, or all");
+  }
+  return normalized;
+}

--- a/src/services/volunteerApplicationSubmitLogic.js
+++ b/src/services/volunteerApplicationSubmitLogic.js
@@ -1,11 +1,13 @@
 import { hasLinkedForm } from "./eventFormLogic.js";
 import { assertEventIsPublic } from "./eventPublicLogic.js";
+import { assertEventRegistrationOpen } from "./eventRegistrationWindowLogic.js";
 import { normalizeEmail } from "./eventRegistrationLogic.js";
 
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
-export function assertVolunteerApplicationAllowed(event) {
+export function assertVolunteerApplicationAllowed(event, now = new Date()) {
   assertEventIsPublic(event);
+  assertEventRegistrationOpen(event, now);
 
   if (!hasLinkedForm(event, "volunteerFormId")) {
     throw new Error("Volunteer applications are not enabled for this event");

--- a/tests/public/events/eventCheckoutService.test.js
+++ b/tests/public/events/eventCheckoutService.test.js
@@ -7,10 +7,13 @@ import {
 } from "../../../src/services/eventCheckoutLogic.js";
 
 describe("eventCheckoutLogic", () => {
+  const eventDate = "2026-08-01T18:00:00.000Z";
+  const beforeEvent = new Date("2026-07-01T00:00:00.000Z");
   const event = {
     _id: "64a000000000000000000010",
     type: "paid",
     status: "published",
+    eventDate,
     maxAttendees: 10,
   };
   const ticketType = {
@@ -52,19 +55,31 @@ describe("eventCheckoutLogic", () => {
 
   it("allows checkout when event and ticket capacities are available", () => {
     expect(() =>
-      assertEventTicketCheckoutAllowed(event, ticketType, 2, 8)
+      assertEventTicketCheckoutAllowed(event, ticketType, 2, 8, beforeEvent)
     ).not.toThrow();
   });
 
   it("rejects checkout when event capacity is exceeded", () => {
     expect(() =>
-      assertEventTicketCheckoutAllowed(event, ticketType, 2, 9)
+      assertEventTicketCheckoutAllowed(event, ticketType, 2, 9, beforeEvent)
     ).toThrow("Event does not have enough remaining capacity");
   });
 
   it("rejects checkout when ticket capacity is exceeded", () => {
     expect(() =>
-      assertEventTicketCheckoutAllowed(event, ticketType, 4, 1)
+      assertEventTicketCheckoutAllowed(event, ticketType, 4, 1, beforeEvent)
     ).toThrow("Ticket type is not available for purchase");
+  });
+
+  it("rejects checkout after eventDate", () => {
+    expect(() =>
+      assertEventTicketCheckoutAllowed(
+        event,
+        ticketType,
+        1,
+        0,
+        new Date(eventDate)
+      )
+    ).toThrow("Registration for this event has closed");
   });
 });

--- a/tests/public/events/eventRegistrationLogic.test.js
+++ b/tests/public/events/eventRegistrationLogic.test.js
@@ -10,6 +10,7 @@ describe("eventRegistrationLogic", () => {
   const freeEvent = {
     type: "free",
     status: "published",
+    eventDate: "2026-08-01T18:00:00.000Z",
   };
 
   it("normalizes email addresses for duplicate checks", () => {
@@ -47,12 +48,24 @@ describe("eventRegistrationLogic", () => {
   });
 
   it("allows free RSVP only for published free events", () => {
-    expect(() => assertFreeEventRegistration(freeEvent)).not.toThrow();
+    const beforeEvent = new Date("2026-07-01T00:00:00.000Z");
     expect(() =>
-      assertFreeEventRegistration({ ...freeEvent, type: "paid" })
+      assertFreeEventRegistration(freeEvent, beforeEvent)
+    ).not.toThrow();
+    expect(() =>
+      assertFreeEventRegistration({ ...freeEvent, type: "paid" }, beforeEvent)
     ).toThrow("Free RSVP is only available for free events");
     expect(() =>
-      assertFreeEventRegistration({ ...freeEvent, status: "draft" })
+      assertFreeEventRegistration({ ...freeEvent, status: "draft" }, beforeEvent)
     ).toThrow("Only published events accept registrations");
+  });
+
+  it("blocks free RSVP after eventDate", () => {
+    expect(() =>
+      assertFreeEventRegistration(
+        freeEvent,
+        new Date("2026-08-01T18:00:00.000Z")
+      )
+    ).toThrow("Registration for this event has closed");
   });
 });

--- a/tests/public/events/eventRegistrationWindowLogic.test.js
+++ b/tests/public/events/eventRegistrationWindowLogic.test.js
@@ -1,0 +1,47 @@
+/*eslint-disable no-undef */
+import {
+  assertEventRegistrationOpen,
+  isEventRegistrationOpen,
+  REGISTRATION_CLOSED_MESSAGE,
+} from "../../../src/services/eventRegistrationWindowLogic.js";
+
+describe("eventRegistrationWindowLogic", () => {
+  const eventDate = "2026-08-01T18:00:00.000Z";
+  const event = { eventDate };
+
+  it("is open when now is before eventDate", () => {
+    expect(
+      isEventRegistrationOpen(event, new Date("2026-08-01T17:59:59.999Z"))
+    ).toBe(true);
+  });
+
+  it("is closed when now equals eventDate", () => {
+    expect(isEventRegistrationOpen(event, new Date(eventDate))).toBe(false);
+  });
+
+  it("is closed when now is after eventDate", () => {
+    expect(
+      isEventRegistrationOpen(event, new Date("2026-08-01T18:00:00.001Z"))
+    ).toBe(false);
+  });
+
+  it("is closed when eventDate is missing or invalid", () => {
+    expect(isEventRegistrationOpen({}, new Date(eventDate))).toBe(false);
+    expect(
+      isEventRegistrationOpen({ eventDate: "not-a-date" }, new Date(eventDate))
+    ).toBe(false);
+    expect(isEventRegistrationOpen(null, new Date(eventDate))).toBe(false);
+  });
+
+  it("assertEventRegistrationOpen allows open events", () => {
+    expect(() =>
+      assertEventRegistrationOpen(event, new Date("2026-07-01T00:00:00.000Z"))
+    ).not.toThrow();
+  });
+
+  it("assertEventRegistrationOpen rejects closed events", () => {
+    expect(() =>
+      assertEventRegistrationOpen(event, new Date("2026-08-02T00:00:00.000Z"))
+    ).toThrow(REGISTRATION_CLOSED_MESSAGE);
+  });
+});

--- a/tests/public/events/eventTicketService.test.js
+++ b/tests/public/events/eventTicketService.test.js
@@ -20,9 +20,9 @@ describe("eventTicketLogic", () => {
     ticketTypes: [],
   };
 
-  it("computes the default ticket expiry one day after the event date", () => {
+  it("computes the default ticket expiry as the event date", () => {
     expect(computeDefaultExpiry(eventDate).toISOString()).toBe(
-      "2026-08-02T18:00:00.000Z"
+      "2026-08-01T18:00:00.000Z"
     );
   });
 
@@ -44,7 +44,7 @@ describe("eventTicketLogic", () => {
       expirySource: "auto",
       isActive: true,
     });
-    expect(payload.expiresAt.toISOString()).toBe("2026-08-02T18:00:00.000Z");
+    expect(payload.expiresAt.toISOString()).toBe("2026-08-01T18:00:00.000Z");
   });
 
   it("marks ticket expiry as manual when an override is provided", () => {
@@ -68,7 +68,7 @@ describe("eventTicketLogic", () => {
         {
           _id: "auto-ticket",
           name: "Early Bird",
-          expiresAt: new Date("2026-08-02T18:00:00.000Z"),
+          expiresAt: new Date("2026-08-01T18:00:00.000Z"),
           expirySource: "auto",
         },
         {
@@ -82,7 +82,7 @@ describe("eventTicketLogic", () => {
     );
 
     expect(tickets[0].expiresAt.toISOString()).toBe(
-      "2026-09-02T18:00:00.000Z"
+      "2026-09-01T18:00:00.000Z"
     );
     expect(tickets[1].expiresAt.toISOString()).toBe(
       "2026-07-15T18:00:00.000Z"

--- a/tests/public/events/eventWhenFilter.test.js
+++ b/tests/public/events/eventWhenFilter.test.js
@@ -1,0 +1,29 @@
+/*eslint-disable no-undef */
+import {
+  EVENT_WHEN_FILTERS,
+  resolvePublicWhenFilter,
+} from "../../../src/services/eventWhenLogic.js";
+
+describe("eventWhenLogic", () => {
+  it("defaults empty when to upcoming", () => {
+    expect(resolvePublicWhenFilter(undefined)).toBe("upcoming");
+    expect(resolvePublicWhenFilter("")).toBe("upcoming");
+    expect(resolvePublicWhenFilter("  ")).toBe("upcoming");
+  });
+
+  it("accepts upcoming, past, and all", () => {
+    expect(resolvePublicWhenFilter("upcoming")).toBe("upcoming");
+    expect(resolvePublicWhenFilter("PAST")).toBe("past");
+    expect(resolvePublicWhenFilter("All")).toBe("all");
+  });
+
+  it("rejects unknown when values", () => {
+    expect(() => resolvePublicWhenFilter("tomorrow")).toThrow(
+      "Invalid when filter. Use upcoming, past, or all"
+    );
+  });
+
+  it("exposes the allowlist used by the public API", () => {
+    expect([...EVENT_WHEN_FILTERS].sort()).toEqual(["all", "past", "upcoming"]);
+  });
+});

--- a/tests/public/events/volunteerApplicationSubmitLogic.test.js
+++ b/tests/public/events/volunteerApplicationSubmitLogic.test.js
@@ -6,25 +6,42 @@ import {
 } from "../../../src/services/volunteerApplicationSubmitLogic.js";
 
 describe("volunteerApplicationSubmitLogic", () => {
+  const eventDate = "2026-08-01T18:00:00.000Z";
+  const beforeEvent = new Date("2026-07-01T00:00:00.000Z");
   const event = {
     status: "published",
+    eventDate,
     volunteerFormId: "64a000000000000000000020",
   };
 
   it("allows volunteer applications for published events with a volunteer form", () => {
-    expect(() => assertVolunteerApplicationAllowed(event)).not.toThrow();
+    expect(() =>
+      assertVolunteerApplicationAllowed(event, beforeEvent)
+    ).not.toThrow();
   });
 
   it("rejects non-public events", () => {
     expect(() =>
-      assertVolunteerApplicationAllowed({ ...event, status: "draft" })
+      assertVolunteerApplicationAllowed(
+        { ...event, status: "draft" },
+        beforeEvent
+      )
     ).toThrow("Event not found");
   });
 
   it("requires a configured volunteer form", () => {
     expect(() =>
-      assertVolunteerApplicationAllowed({ ...event, volunteerFormId: null })
+      assertVolunteerApplicationAllowed(
+        { ...event, volunteerFormId: null },
+        beforeEvent
+      )
     ).toThrow("Volunteer applications are not enabled for this event");
+  });
+
+  it("blocks volunteer applications after eventDate", () => {
+    expect(() =>
+      assertVolunteerApplicationAllowed(event, new Date(eventDate))
+    ).toThrow("Registration for this event has closed");
   });
 
   it("blocks duplicate volunteer applications", () => {


### PR DESCRIPTION
Close free RSVP, paid ticket checkout (including payment confirmation), and volunteer applications once `eventDate` has passed, using a shared registration-window check as the source of truth. Align default ticket auto-expiry with that same cutoff, and let the public events list filter by time window so clients can browse upcoming, past, or all published events without relying on cron or status flips.

**Key changes**
- Add `isEventRegistrationOpen` / `assertEventRegistrationOpen` helpers and unit tests
- Reject free RSVP after `eventDate`
- Reject volunteer applications after `eventDate`
- Reject ticket checkout initialization and payment confirmation after `eventDate`
- Set default auto ticket `expiresAt` to `eventDate` instead of `eventDate + 1 day`
- Support public list query `when=upcoming|past|all` (default `upcoming`), with past sorted newest first